### PR TITLE
Differentiate RENCI from Renaissance Learning

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -19836,7 +19836,7 @@ firecast: firecast!users.noreply.github.com
 	Atlan from 2019-06-01
 firefly2442: firefly2442!users.noreply.github.com
 	Independent until 2016-02-01
-	Renaissance from 2016-02-01 until 2017-03-01
+	Renaissance Learning from 2016-02-01 until 2017-03-01
 	Sandia National Laboratories from 2017-03-01
 fireflycons: fireflycons!users.noreply.github.com
 	RX Global until 2021-12-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -4165,7 +4165,7 @@ himmatb: himmatb!users.noreply.github.com
 	Emirates NBD from 2019-07-01
 hinchliff: hinchliff!users.noreply.github.com
 	Independent until 2016-11-01
-	Renaissance from 2016-11-01 until 2017-12-01
+	Renaissance Computing Institute from 2016-11-01 until 2017-12-01
 	Optiv Security Inc. from 2017-12-01
 hinlopen: hinlopen!users.noreply.github.com
 	Independent until 2020-09-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -4902,7 +4902,7 @@ mac-chaffee: mac-chaffee!users.noreply.github.com, me!macchaffee.com
 	Inmar from 2018-06-01 until 2018-08-01
 	Independent from 2018-08-01 until 2019-05-01
 	Cisco from 2019-05-01 until 2021-06-01
-	Renaissance from 2021-06-01
+	Renaissance Computing Institute from 2021-06-01
 mac9416: mac9416!users.noreply.github.com, michael!crenshaw.dev
 	Independent until 2017-05-01
 	Crutchfield New Media LLC. from 2017-05-01 until 2019-07-01


### PR DESCRIPTION
Looks like "Renaissance Computing Institute (RENCI)" and "Renaissance Learning" got lumped together.

I work for RENCI, as did hinchliff according to linkedin: https://www.linkedin.com/in/hinchliff/

firefly2442 worked for Renaissance Learning: https://carlsonp.github.io/cv/

This should handle everyone currently marked as "Renaissance": https://github.com/cncf/gitdm/blob/bea0546009b5d5622230755c555a2f9689b6a639/company_developers8.txt#L7554