### PR TITLE
remove extraneous duplicate "from" from robbkidd's entry

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -9039,7 +9039,7 @@ robbiezhang: junjiez!microsoft.com, robbiezhang!users.noreply.github.com
 robbkidd: robb!thekidds.org, robbkidd!chef.io, robbkidd!honeycomb.io, robbkidd!users.noreply.github.com
 	Independent until 2015-09-01
 	Chef Software Inc. from 2015-09-01 until 2020-11-22
-	Hound Technology Inc. dba Honeycomb from from 2020-11-22
+	Hound Technology Inc. dba Honeycomb from 2020-11-22
 robbmanes: rmanes!redhat.com
 	Red Hat Inc.
 robbmanes: robb.manes!gmail.com


### PR DESCRIPTION
Not sure when the second "from" snuck in to [my entry](https://github.com/cncf/gitdm.archive/pull/1229). Here's a removal!

