### PR TITLE
chore: add fty4 developer affiliation

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -8521,6 +8521,8 @@ Fryuni: Fryuni!users.noreply.github.com, luiz!lferraz.com
 	Croct · from 2019-09-01
 Fsero: Fsero!users.noreply.github.com, fabian.selles!schibsted.com, fabian.sellesrosa!gmail.com
 	Schibsted Media Group
+fty4: fty4!users.noreply.github.com, marco!task.media, marco.lecheler!mercedes-benz.com
+	Mercedes-Benz Tech Innovation GmbH from 2016-10-01
 Fumesover: Fumesover!users.noreply.github.com
 	Independent until 2019-09-01
 	EPITA from 2019-09-01 until 2020-08-01


### PR DESCRIPTION
I am listed as unknown contributer:

https://github.com/cncf/gitdm/blob/50ada87d75e3565fc92bceb5e8290f650bc209ba/src/allprj_unknown_contributors_recent.csv#L2773

Therefore I want to adding my users affiliation.

