### PR TITLE
update ratnopamc affiliation with Amazon

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -7327,6 +7327,7 @@ ratnadeepb: ratnadeepb!users.noreply.github.com
 ratnopamc: ratnopamc!users.noreply.github.com, ratnopamc!yahoo.com
 	Ericsson until 2021-12-01
 	Independent from 2021-12-01
+	Amazon from 2022-04-18
 ratteler50: dlorant!google.com
 	Google LLC
 rauanmayemir: rauan!mayemir.io, rauanmayemir!users.noreply.github.com


### PR DESCRIPTION
This PR is to update ratnopamc affiliation with Amazon.