### PR TITLE
Updates incorrect affiliation for seans3

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -16423,11 +16423,8 @@ seanpeters86: sean.peters86!icloud.com, seanpeters86!users.noreply.github.com
 	Apple Inc.
 seanqsun: sean!seanqsun.com, sesun!redhat.com
 	Red Hat Inc.
-seans3: seans!google.com, seans3!users.noreply.github.com
+seans3: seans!google.com, seans3!gmail.com, seans3!users.noreply.github.com
 	Google LLC
-seans3: seans3!gmail.com
-	Sony Interactive Entertainment LLC until 2016-08-01
-	Activision Publishing Inc. from 2016-08-01
 seanschneeweiss: sean.schneeweiss!daimler.com, sean.schneeweiss!mercedes-benz.com, seanschneeweiss!users.noreply.github.com
 	Independent until 2020-07-01
 	Mercedes-Benz AG from 2020-07-01


### PR DESCRIPTION
* Corrects developer affiliation by updating developer affiliation for `seans3@gmail.com`.
* Sean Sullivan (seans3@gmail.com and seans@google.com) has only contributed to open source while at Google (since June 12, 2017), and has never worked for Sony **or** Activision.