### PR TITLE
Merge the duplicate "RedHat" with "Red Hat Inc."

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -15550,7 +15550,7 @@ MaxymVlasov: MaxymVlasov!users.noreply.github.com
 	Microsoft Corporation from 2015-07-01 until 2019-10-01
 	SHALB from 2019-10-01
 MayXuQQ: maxu!redhat.com
-	redhat
+	RedHat Inc.
 MayankSainiTk20: mayanksaini09013046!gmail.com
 	Watermark Insights LLC until 2016-04-01
 	Independent from 2016-04-01 until 2016-10-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -5915,7 +5915,7 @@ ahurtaud: ahurtaud!users.noreply.github.com, alban.hurtaud!amadeus.com
 ahus1: ahus1!users.noreply.github.com, alexander.schwartz!gmx.net
 	msg
 ahussey-redhat: ahussey-redhat!users.noreply.github.com
-	RedHat
+	RedHat Inc.
 aibaars: aibaars!users.noreply.github.com
 	Semmle until 2019-09-01
 	GitHub Inc. from 2019-09-01
@@ -11867,7 +11867,7 @@ anoop2811: anoop2811!users.noreply.github.com
 anoopbabu29: anoobabu!cisco.com, anoopbabu29!users.noreply.github.com
 	Cisco
 anoopcs9: anoopcs!cryptolab.net
-	RedHat
+	RedHat Inc.
 anoophp777: anoophp!gmail.com
 	Tata Consultancy Services until 2018-08-01
 	Lowe's India from 2018-08-01 until 2021-05-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -17053,7 +17053,7 @@ elgeorge2k: elgeorge2k!users.noreply.github.com
 	Boulevards until 2019-12-01
 	Metro Newspapers from 2019-12-01
 elgnay: elgnay!users.noreply.github.com
-	RedHat
+	RedHat Inc.
 elgris: elgris!users.noreply.github.com
 	Zalando SE
 elgris: iddqd07!yandex.ru

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -8441,7 +8441,7 @@ marcokrikke: marco!eveoh.nl
 	Eveoh B.V.
 marcolan018: llan!redhat.com, marcolan018!users.noreply.github.com
 	International Business Machines Corporation until 2020-01-01
-	RedHat from 2020-01-01
+	RedHat Inc. from 2020-01-01
 marcoliceti: marco.liceti!gmail.com, marcoliceti!users.noreply.github.com
 	ClickMeter until 2015-03-01
 	Independent from 2015-03-01 until 2015-06-01
@@ -13137,7 +13137,7 @@ michael-robbins: michael-robbins!users.noreply.github.com
 	Xero from 2020-10-01
 michael-valdron: michael.valdron!gmail.com
 	Independent until 2021-01-01
-	RedHat from 2021-01-01
+	RedHat Inc. from 2021-01-01
 michael-w-williams: 31933474+michael-w-williams!users.noreply.github.com, michael.w.williams!oracle.com
 	Oracle America Inc.
 michael4screen: michael4screen!users.noreply.github.com

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -5570,7 +5570,7 @@ priyansu-nayak: priyansu-nayak!users.noreply.github.com
 priyawadhwa: priyawadhwa!google.com, priyawadhwa!users.noreply.github.com
 	Google LLC
 priyshar01: priyshar01!users.noreply.github.com
-	Redhat
+	RedHat Inc.
 prksu: prksu!users.noreply.github.com, prksu.sh!gmail.com
 	Independent until 2018-01-01
 	Confidential from 2018-01-01 until 2019-06-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -14953,7 +14953,7 @@ wojciechka: wojciechka!users.noreply.github.com
 	VMware Inc. from 2017-12-01 until 2019-10-01
 	InfluxData Inc from 2019-10-01
 wojnarfilip: wojnarfilip!users.noreply.github.com
-	RedHat
+	RedHat Inc.
 wojtek-t: wojtek-t!users.noreply.github.com, wojtekt!google.com
 	Google LLC
 wojtek-viirtue: wojtek-viirtue!users.noreply.github.com
@@ -17571,7 +17571,7 @@ yifan-gu-anchorage: yifan-gu-anchorage!users.noreply.github.com
 	Mesosphere until 2014-08-01
 	Independent from 2014-08-01 until 2015-02-01
 	CoreOS Inc. from 2015-02-01 until 2018-03-01
-	RedHat from 2018-03-01 until 2018-10-01
+	RedHat Inc. from 2018-03-01 until 2018-10-01
 	Kubernetes Pilot from 2018-10-01 until 2022-02-01
 	Anchor Labs Inc from 2022-02-01
 yifang123: eric.fangyi!huawei.com


### PR DESCRIPTION
With me working for Red Hat myself, I did a review of the committers listed for "RedHat" and this should actually be "Red Hat Inc." like the others. This should fix the contributor statistics for the Keycloak project.