### PR TITLE
Fix spelling mistake in affiliation for ahus1

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -5914,7 +5914,7 @@ ahurtaud: ahurtaud!users.noreply.github.com, alban.hurtaud!amadeus.com
 	Amadeus
 ahus1: ahus1!users.noreply.github.com, alexander.schwartz!gmx.net, alexander.schwartz!msg-systems.com, aschwart!redhat.com
 	msg until 2021-12-31
-	Rad Hat Inc. from 2021-12-31
+	Red Hat Inc. from 2021-12-31
 ahussey-redhat: ahussey-redhat!users.noreply.github.com
 	Red Hat Inc.
 aibaars: aibaars!users.noreply.github.com


### PR DESCRIPTION
Looking 2f9c55c41ee10a962967f622a790ba52362cddc1, the company name changed from "Red Hat" to "Rad Hat" - this fixes this spelling mistake.