### PR TITLE
Update mattray's employers

### DIFF
--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -4564,7 +4564,7 @@ Chef Software Inc.:
 	johnewart: john!johnewart.net, john!unixninjas.org from 2014-07-01 until 2015-01-01
 	jonsmorrow: jmorrow!chef.io
 	juliandunn: jdunn!aquezada.com, jdunn!chef.io until 2019-01-01
-	mattray: matt!chef.io, matthewhray!gmail.com
+	mattray: matt!chef.io, matthewhray!gmail.com, github@mattray.dev until 2021-05-01
 	mfdii: mfdii!users.noreply.github.com, michael!ducy.org until 2017-11-01
 	prasek: prasek!users.noreply.github.com from 2018-07-01 until 2019-04-01
 	robbkidd: robb!thekidds.org, robbkidd!chef.io, robbkidd!honeycomb.io, robbkidd!users.noreply.github.com from 2015-09-01 until 2020-11-22

--- a/company_developers6.txt
+++ b/company_developers6.txt
@@ -9108,6 +9108,7 @@ KubeSphere:
 	zryfish: zryfish!users.noreply.github.com, zw0948!gmail.com
 Kubecost:
 	ErnestG4: ErnestG4!users.noreply.github.com
+	mattray: matthewhray!gmail.com, github!mattray.dev from 2022-04-01
 Kubeflow:
 	jbottum: joshbottum!gmail.com from 2022-02-01
 KuberFirma:


### PR DESCRIPTION
I left Chef in May of 2021 and started with Kubecost in April of 2022