### PR TITLE
Add developers affiliation for haoranleo

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -4973,6 +4973,14 @@ haooliveira84: haooliveira84!users.noreply.github.com
 	Grupo Boticário from 2021-10-01
 haoqing0110: haoqing!cn.ibm.com, haoqing0110!users.noreply.github.com, sander.huijsen!gmail.com
 	International Business Machines Corporation
+haoranleo: haoran.leonard!gmail.com, haoranr!amazon.com
+	Independent until 2018-03-01
+	Hikvision from 2018-03-01 until 2018-06-01
+	Independent from 2018-06-01 until 2019-05-01
+	TuSimple from 2019-05-01 until 2019-08-01
+	Independent from 2019-08-01 until 2020-07-01
+	VMware Inc. from 2020-07-01 until 2022-10-01
+	Amazon from 2022-10-01
 haorenfsa: haorenfsa!gmail.com, haorenfsa!users.noreply.github.com
 	Zilliz
 haoruan: haoruan!users.noreply.github.com


### PR DESCRIPTION
Add developers affiliation for `haoranleo` (some info are copied from previous gitlab id `HL-EverGreen`)