### PR TITLE
Change affiliation for pyohannes to Grafana Labs

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -9342,8 +9342,10 @@ pymander: earneson!arnesonium.com
 pymhq: pymhq!users.noreply.github.com, pymhq001!gmail.com, yimipeng!amazon.com
 	Independent until 2016-03-14
 	AWS from 2016-03-14
-pyohannes: johannes!johannes.tax, jtax!newrelic.com
-	New Relic Inc.
+pyohannes: johannes!johannes.tax, jtax!newrelic.com, johannestax!microsoft.com, johannes.tax@grafana.com
+	New Relic Inc. until 2021-11-30
+	Microsoft Corporation from 2021-12-01 until 2023-07-25
+	Grafana Labs from 2023-07-26
 pyr: pyr!spootnik.org
 	Akenes SA (Exoscale)
 pyr0hu: pyr0hu!users.noreply.github.com


### PR DESCRIPTION
Update company affiliation to Grafana, also added the past affiliation to Microsoft.