### PR TITLE
Affiliate mike-weiner with IBM

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -21134,6 +21134,8 @@ mike-seagull: hollister.michael!gmail.com
 	CrossBrowserTesting.com LLC
 mike-stewart: mike-stewart!users.noreply.github.com
 	Introhive
+mike-weiner: 47571709+mike-weiner!users.noreply.github.com
+	International Business Machines Corporation
 mike1808: mike1808!users.noreply.github.com
 	Independent until 2014-07-01
 	Truthly from 2014-07-01 until 2016-01-01


### PR DESCRIPTION
This PR affiliates my GitHub account (`mike-weiner`) with my current employer International Business Machines Corporation (`IBM`). 