### PR TITLE
Update affiliation for stmcginnis

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -13256,12 +13256,13 @@ stmaute: stmaute!users.noreply.github.com
 	Bosch from 2015-09-01 until 2015-11-01
 	Independent from 2015-11-01 until 2016-03-01
 	Bosch from 2016-03-01
-stmcginnis: sean.mcginnis!gmail.com, smcginnis!vmware.com, stmcg!amazon.com, stmcginnis!users.noreply.github.com
+stmcginnis: sean.mcginnis!gmail.com, sean!lambdal.com, smcginnis!vmware.com, stmcg!amazon.com, sean.mcginnis!dell.com, sean_mcginnis!dell.com, sean.mcginnis!huawei.com, stmcginnis!users.noreply.github.com
 	Dell until 2017-04-07
 	Huawei Technologies Co. Ltd from 2017-04-07 until 2019-06-01
 	Dell from 2019-06-01 until 2020-09-17
 	VMware Inc. from 2020-09-17 until 2022-07-15
-	AWS from 2022-07-15
+	AWS from 2022-07-15 until 2023-11-27
+	Lambda Labs from 2023-11-27
 stmordret: pierre-yves.mordret!st.com
 	STMicroelectronics International N.V.
 stmpy: stmpy!me.com, stmpy!users.noreply.github.com


### PR DESCRIPTION
This updates to my current affiliation and adds some missing historical email addresses from past companies.