### PR TITLE
Correct affiliation for @matt-hensley

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -22075,7 +22075,7 @@ matt-hensley: matt-hensley!users.noreply.github.com, matthew.hensley!grafana.com
 	Independent until 2016-02-01
 	QSR from 2016-02-01 until 2017-07-01
 	Switcher from 2017-07-01 until 2023-05-01
-	Grafana from 2023-05-01
+	Grafana Labs from 2023-05-01
 matt-kwong: matt-kwong!users.noreply.github.com
 	Symantec Corporation
 matt-kwong: mattkwong!google.com


### PR DESCRIPTION
Affiliate @matt-hensley with Grafana Labs

Appears to be have been overwritten by a data import [in this commit](https://github.com/cncf/gitdm/commit/9fb88522a379ed1d9ff6661e6770b1777a336459#diff-ba7be0b9987ea363432bffb3c63f8336da54137c22bf204fb71fd028ca3cda0aR17550).