### PR TITLE
Add mapping from Grafana to Grafana Labs

### DIFF
--- a/src/mapping.json
+++ b/src/mapping.json
@@ -1414,6 +1414,7 @@
   "Gopath": "GoPath LLC.",
   "Government": "The Government Report",
   "Government Digital Service": "Goverment Digital Service",
+  "Grafana": "Grafana Labs",
   "Grakn": "Grakn Labs Ltd",
   "Grandsla": "GRANDSLA INC.",
   "Granular": "Granular Inc",


### PR DESCRIPTION
Map Grafana -> Grafana Labs

At Grafana Labs, we realized that a few people are being mapped to Grafana instead of Grafana Labs. As this is a common pattern, I would like to automatically map Grafana -> Grafana Labs. I'm not 100% sure the way to go is how I'm proposing here, but I'm open to changing this.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
