### PR TITLE
Elasticsearch-affiliated developers: Add `from` dates for Michal and Shaunak

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -2667,7 +2667,7 @@ michalno1: michalno1!users.noreply.github.com
 	Independent from 2018-09-01 until 2018-11-01
 	SonarSource from 2018-11-01
 michalpristas: michal.pristas!elastic.co, michal.pristas!gmail.com, michalpristas!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. from 2023-11-03
 michalschott: michalschott!users.noreply.github.com, schott.michal!gmail.com
 	Kainos Software until 2017-08-01
 	Schibsted Media Group from 2017-08-01 until 2017-12-01

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -12115,7 +12115,7 @@ ycjiang50: ycjiang50!users.noreply.github.com
 ycnian: ycnian!gmail.com
 	Independent
 ycombinator: shaunak!elastic.co, ycombinator!gmail.com, ycombinator!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. from 2023-11-03
 ycsk02: ycsk02!hotmail.com, ycsk02!users.noreply.github.com
 	VectorCloud
 yctn: yctn!users.noreply.github.com


### PR DESCRIPTION
This PR adds `from` dates for the two Elasticsearch developers added in https://github.com/cncf/gitdm/pull/202, @michalpristas and @ycombinator.