### PR TITLE
Elasticsearch-affiliated developers: Adding `until` clauses for developers no longer at the company

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -7122,7 +7122,7 @@ DanLipsitt: DanLipsitt!users.noreply.github.com, danlipsitt!gmail.com
 	Independent from 2018-01-01
 DanRoscigno: DanRoscigno!users.noreply.github.com, dan!roscigno.com
 	International Business Machines Corporation until 2018-01-01
-	Elasticsearch Inc. from 2018-01-01
+	Elasticsearch Inc. from 2018-01-01 until 2022-05-09
 DanSmith: dan!colectica.com
 	Colectica and Algenta Technologies LLC
 DanSmith70: DanSmith70!users.noreply.github.com, daniel.smith!kaazing.com, dbsmith!google.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -455,7 +455,7 @@ SeanFeldman: SeanFeldman!users.noreply.github.com
 SeanHQF: haoqf!linux.vnet.ibm.com
 	International Business Machines Corporation
 SeanHeelan: SeanHeelan!users.noreply.github.com, sean!heelan.io, sean.heelan!elastic.co
-	Elasticsearch Inc.
+	Elasticsearch Inc. until 2023-12-11
 SeanHood: SeanHood!users.noreply.github.com
 	KCOM until 2015-10-01
 	Independent from 2015-10-01 until 2018-08-01
@@ -9731,7 +9731,7 @@ agunnerson-ibm: agunnerson-ibm!users.noreply.github.com, andrew.gunnerson!us.ibm
 agup006: a!treasure-data.com, agup006!gmail.com
 	Adobe Inc.
 agup006: agup006!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. until 2020-05-20
 agupta-cb: agupta-cb!users.noreply.github.com
 	Shahi until 2015-03-01
 	GenX from 2015-03-01 until 2017-01-01
@@ -17469,7 +17469,7 @@ anwesh-b: anwesh-b!users.noreply.github.com
 anyasabo: anyasabo!users.noreply.github.com
 	Rackspace until 2017-03-01
 	ObjectRocket from 2017-03-01 until 2019-05-01
-	Elasticsearch Inc. from 2019-05-01
+	Elasticsearch Inc. from 2019-05-01 until 2022-01-20
 anycodes: anycodes!users.noreply.github.com, service!52exe.cn
 	Alibaba Group
 anygaard: anygaard!inselo.no
@@ -18004,7 +18004,7 @@ aravindhp: aravindhp!users.noreply.github.com
 aravindputrevu: aravindputrevu!users.noreply.github.com
 	Syntel Inc until 2014-09-01
 	McAfee LLC from 2014-09-01 until 2017-11-01
-	Elasticsearch Inc. from 2017-11-01
+	Elasticsearch Inc. from 2017-11-01 until 2022-11-15
 aravindvnair99: aravindvnair99!users.noreply.github.com
 	Independent until 2018-02-01
 	Finch IT Solutions from 2018-02-01 until 2019-10-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -8002,7 +8002,7 @@ charithe: charithe!users.noreply.github.com
 	Independent from 2018-09-01 until 2019-01-01
 	Pusher Ltd. from 2019-01-01 until 2019-04-01
 	Independent from 2019-04-01 until 2019-07-01
-	Elasticsearch Inc. from 2019-07-01
+	Elasticsearch Inc. from 2019-07-01 until 2021-04-09
 charles-d-burton: charles-d-burton!users.noreply.github.com, charles.d.burton!gmail.com
 	Arris
 charles-dyfis-net: chaduffy!cisco.com, charles!dyfis.net
@@ -14660,7 +14660,7 @@ danieljimeneznz: danieljimeneznz!users.noreply.github.com
 danielkhan: daniel!khan.io, danielkhan!users.noreply.github.com
 	CROWD LYNX until 2015-03-01
 	Dynatrace LLC from 2015-03-01 until 2021-08-31
-	Elasticsearch Inc. from 2021-08-31
+	Elasticsearch Inc. from 2021-08-31 until 2022-06-30
 danielkimuipath: danielkimuipath!users.noreply.github.com
 	Independent until 2015-06-01
 	Independent from 2015-06-01 until 2015-07-01
@@ -19840,7 +19840,7 @@ djs55: djs55!users.noreply.github.com
 	Unikernel from 2015-09-01 until 2016-01-01
 	Docker Inc. from 2016-01-01
 djschny: djschny!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. until 2017-05-19
 djsd123: djsd123!users.noreply.github.com
 	Greater London Authority
 djsly: djsly!users.noreply.github.com, sylvain.boily!gmail.com, sylvain.boily!nuance.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -4857,7 +4857,7 @@ fatimaafridi: fatimaafridi!users.noreply.github.com
 	Bentley Motors Limited from 2020-11-01
 fatmcgav: fatmcgav!gmail.com, fatmcgav!users.noreply.github.com
 	Fujitsu Limited until 2018-05-01
-	Elasticsearch Inc. from 2018-05-01
+	Elasticsearch Inc. from 2018-05-01 until 2022-07-08
 fatpat: fatpat!users.noreply.github.com
 	SIA Worldline Latvia until 2018-09-01
 	OpenIO SAS from 2018-09-01 until 2020-10-01
@@ -7704,7 +7704,7 @@ fwilhe: 2292245+fwilhe!users.noreply.github.com, florian.wilhelm02!sap.com
 fxbonnet: fx!apache.org
 	Apache
 fxdgear: fxdgear!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. until 2022-05-06
 fxfactorial: edgar.factorial!gmail.com, fxfactorial!users.noreply.github.com
 	Independent until 2015-11-01
 	Online Media Group Inc from 2015-11-01 until 2016-06-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -548,7 +548,7 @@ jethr0null: jethr0null!users.noreply.github.com, mnikki137!gmail.com
 	Pivotal from 2015-05-01 until 2016-05-01
 	Apcera from 2016-05-01 until 2018-04-01
 	Ericsson from 2018-04-01 until 2018-07-01
-	Elasticsearch Inc. from 2018-07-01
+	Elasticsearch Inc. from 2018-07-01 until 2023-01-17
 jetpackdanger: brian!stellaservice.com, jetpackdanger!users.noreply.github.com, paul.collins!canonical.com
 	Canonical Ltd.
 jetsanix: jetsanix!users.noreply.github.com
@@ -8416,7 +8416,7 @@ karencfv: karencfv!users.noreply.github.com
 	Independent until 2016-10-01
 	SilverStripe Limited from 2016-10-01 until 2017-09-01
 	Loyalty NZ from 2017-09-01 until 2018-07-01
-	Elasticsearch Inc. from 2018-07-01
+	Elasticsearch Inc. from 2018-07-01 until 2021-07-02
 karenhchu: karen.chu!microsoft.com, karenhchu!users.noreply.github.com
 	Microsoft Corporation
 karenin-overseas: karenin-overseas!users.noreply.github.com
@@ -13515,7 +13515,7 @@ kwilczynski: krzysztof.wilczynski!linux.com, kw!linux.com, kwilczynski!users.nor
 	OLX Group from 2017-10-01 until 2018-03-01
 	Joyent Inc. from 2018-03-01 until 2018-07-01
 	Tenable Network Security Inc. from 2018-07-01 until 2019-03-01
-	Elasticsearch Inc. from 2019-03-01
+	Elasticsearch Inc. from 2019-03-01 until 2019-10-18
 kwinkel: github!kevinwinkel.de, kwinkel!users.noreply.github.com
 	OneHourTranslation until 2014-02-01
 	Dinerware from 2014-02-01 until 2019-11-01
@@ -17693,7 +17693,6 @@ lreuven: lreuven!users.noreply.github.com
 	Independent from 2018-07-01 until 2018-10-01
 	HiredScore from 2018-10-01 until 2019-04-01
 	Elasticsearch Inc. from 2019-04-01 until 2020-07-01
-	Elasticsearch Inc. from 2020-07-01
 lrg-ti: lrg!ti.com
 	Texas Instruments Incorporated
 lrgar: contact!lgarcia.dev, lrgar!users.noreply.github.com
@@ -22689,7 +22688,7 @@ matsbror: mats!embeinnovation.com, matsbror!users.noreply.github.com
 	Satalia from 2017-08-01 until 2020-07-01
 	SnT from 2020-07-01
 matschaffer: mat!schaffer.me, matschaffer!users.noreply.github.com
-	Elasticsearch Inc.
+	Elasticsearch Inc. from 2015-08-01 until 2022-10-01
 matschaffer-roblox: matschaffer-roblox!users.noreply.github.com
 	Netflix Inc. until 2014-12-01
 	Stellar from 2014-12-01 until 2015-07-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -4097,7 +4097,7 @@ roncain: roncain!microsoft.com, roncain!users.noreply.github.com
 	Microsoft Corporation
 roncohen: cohen1!gmail.com, ron!elastic.co, roncohen!users.noreply.github.com
 	Opbeat until 2017-04-01
-	Elasticsearch Inc. from 2017-04-01
+	Elasticsearch Inc. from 2017-04-01 until 2020-11-30
 ronenil: ronen.arad!intel.com
 	Intel Corporation
 ronenkat: ronenkat!il.ibm.com
@@ -22800,7 +22800,7 @@ thomasdullien: thomasdullien!users.noreply.github.com
 	Independent from 2015-08-01 until 2016-08-01
 	Google LLC from 2016-08-01 until 2018-12-01
 	optimyze from 2018-12-01 until 2021-11-01
-	Elasticsearch Inc. from 2021-11-01
+	Elasticsearch Inc. from 2021-11-01 until 2024-01-31
 thomasf: thomasf!jossystem.se, thomasf!users.noreply.github.com
 	Various
 thomasf7: thomasf7!users.noreply.github.com

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -3743,7 +3743,7 @@ uroy-personal: umesh.roysqr!gmail.com, uroy-personal!users.noreply.github.com
 	CNCF from 2021-09-01
 urso: urso!users.noreply.github.com
 	Red Hat Inc. until 2015-07-01
-	Elasticsearch Inc. from 2015-07-01
+	Elasticsearch Inc. from 2015-07-01 until 2021-09-03
 ursuad: adrian.ursu!hivehome.com, development!advance-leap.com, ursuad!users.noreply.github.com
 	Open Credo Limited
 uruddarraju: rudaykumarraju!gmail.com, uday.ruddarraju!robinhood.com, uruddarraju!ebay.com, uruddarraju!users.noreply.github.com


### PR DESCRIPTION
This PR adds `until` clauses for developers who no longer work at Elasticsearch.