### PR TITLE
Update affiliation for `pushkarj`

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -21634,6 +21634,10 @@ pururaj1908: pdave2!ncsu.edu, pururaj1908!users.noreply.github.com
 	Independent from 2019-07-01 until 2020-05-01
 	Polyapp from 2020-05-01 until 2020-08-01
 	Independent from 2020-08-01
+pushkarj: pujoglek!visa.com, pushkarj!users.noreply.github.com, pushkarj.at.work@gmail.com, pjoglekar!vmware.com, pushkar.joglekar1789!gmail.com
+	Visa Inc. until 2021-03-05
+	VMware from 2021-03-08 until 2022-10-03
+	Independent from 2022-10-04
 pushm0v: pushm0v.development!gmail.com
 	PT QDC until 2014-09-01
 	GOJEK from 2014-09-01 until 2018-09-01


### PR DESCRIPTION
This was missing and maybe because of that wrong affiliation was getting picked up here: https://github.com/cncf/gitdm/blob/master/src/cncf-config/email-map