### PR TITLE
Update affiliation for timebertt

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -1617,7 +1617,7 @@ timdorr: git!timdorr.com, timdorr!timdorr.com, timdorr!users.noreply.github.com
 timebertt: tim.ebert!sap.com, timebertt!gmail.com, timebertt!users.noreply.github.com
 	Independent until 2016-09-01
 	SAP from 2016-09-01 until 2022-11-01
-	Schwarz IT from 2022-11-01
+	STACKIT from 2022-11-01
 timeimp: timp_members!me.com
 	Apple Inc.
 timeshift92: timeshift92!outlook.com, timeshift92!users.noreply.github.com


### PR DESCRIPTION
We generally want to act as STACKIT officially even though we are part of the Schwarz IT entity from a legal perspective.