### PR TITLE
Update affiliation for DataCore Software employees

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -1207,7 +1207,7 @@ Abhilash-Chandran: csc.abhilash!gmail.com
 	Independent from 2014-07-01 until 2015-08-01
 	Lufthansa Industry Solutions from 2015-08-01 until 2019-06-01
 	NXP Semiconductors Netherlands B.V. from 2019-06-01
-Abhinandan-Purkait: Abhinandan-Purkait!users.noreply.github.com, purkaitabhinandan!gmail.com, abhinandan.purkait!datacore.com
+Abhinandan-Purkait: Abhinandan-Purkait!users.noreply.github.com, purkaitabhinandan!gmail.com, abhinandan.purkait!mayadata.io, abhinandan.purkait!datacore.com
 	Independent until 2019-05-01
 	Inland World Logistics from 2019-05-01 until 2019-07-01
 	Independent from 2019-07-01 until 2020-05-01

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -1207,11 +1207,12 @@ Abhilash-Chandran: csc.abhilash!gmail.com
 	Independent from 2014-07-01 until 2015-08-01
 	Lufthansa Industry Solutions from 2015-08-01 until 2019-06-01
 	NXP Semiconductors Netherlands B.V. from 2019-06-01
-Abhinandan-Purkait: Abhinandan-Purkait!users.noreply.github.com, purkaitabhinandan!gmail.com
+Abhinandan-Purkait: Abhinandan-Purkait!users.noreply.github.com, purkaitabhinandan!gmail.com, abhinandan.purkait!datacore.com
 	Independent until 2019-05-01
 	Inland World Logistics from 2019-05-01 until 2019-07-01
 	Independent from 2019-07-01 until 2020-05-01
-	MayaData Inc. (f/k/a CloudByte Inc) from 2020-05-01
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-05-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 Abhishek-569: Abhishek-569!users.noreply.github.com
 	Independent
 Abhishek-Govula: abhishek520.govula!gmail.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -7555,6 +7555,8 @@ abhijitherekar: abhijitherekar!users.noreply.github.com, in.abhijit!gmail.com
 	Yahoo! Inc. from 2018-09-01 until 2019-04-01
 	Aporeto Inc. from 2019-04-01 until 2019-11-01
 	Palo Alto Networks from 2019-11-01
+abhilashshetty04: abhilashshetty04!users.noreply.github.com, abhilash.shetty!datacore.com
+	DataCore Software from 2021-11-01
 abhilipsasahoo03: abhilipsasahoo03!gmail.com, abhilipsasahoo03!users.noreply.github.com
 	Independent until 2022-03-01
 	GirlScript Foundation from 2022-03-01 until 2022-06-01
@@ -21791,9 +21793,10 @@ avish42: avish42!users.noreply.github.com
 	Successive from 2019-02-01
 avishayb: avishayb!radware.com
 	Radware Inc.
-avishnu: avishnu!users.noreply.github.com, vishnu.attur!gmail.com, vishnu.attur!mayadata.io
+avishnu: avishnu!users.noreply.github.com, vishnu.attur!gmail.com, vishnu.attur!mayadata.io, vishnu.attur!datacore.com
 	CloudByte Inc until 2017-11-01
-	MayaData Inc. (f/k/a CloudByte Inc) from 2017-11-01
+	MayaData Inc. (f/k/a CloudByte Inc) from 2017-11-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 avivex1000: avivex1000!users.noreply.github.com
 	Israeli Military Intelligence until 2018-10-01
 	Double beat LTD from 2018-10-01 until 2018-12-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -2425,8 +2425,9 @@ blaise-sumo: blaise-sumo!users.noreply.github.com
 	Shape until 2017-10-01
 	Infrastructure Proving Grounds from 2017-10-01 until 2019-02-01
 	Sumo Logic Inc. from 2019-02-01
-blaisedias: blaisedias!mayadata.io, blaisedias!users.noreply.github.com
-	MayaData Inc. (f/k/a CloudByte Inc)
+blaisedias: blaisedias!mayadata.io, blaisedias!users.noreply.github.com, blaise.dias!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-02-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 blak3mill3r: blak3mill3r!gmail.com, blak3mill3r!users.noreply.github.com
 	Tengrade until 2015-03-01
 	IRIS.TV from 2015-03-01
@@ -10538,6 +10539,9 @@ chrisunder: chrisunder!users.noreply.github.com
 chrisvugrinec: chrisvugrinec!users.noreply.github.com
 	Red Hat Inc. until 2016-02-01
 	Microsoft Corporation from 2016-02-01
+chriswldenyer: chriswldenyer!users.noreply.github.com, christopher.denyer!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-02-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 chriswright: chrisw!sous-sol.org, chriswright!users.noreply.github.com
 	Red Hat Inc.
 chriswwalz: chriswwalz!users.noreply.github.com
@@ -16413,6 +16417,12 @@ dastrobu: dastrobu!users.noreply.github.com
 	BMW from 2018-06-01
 databus23: databus23!users.noreply.github.com, fabian!progra.de, fabian.ruff!sap.com
 	SAP
+datacore-pavan-venkat: datacore-pavan-venkat!users.noreply.github.com, pavanvenkat.layam!datacore.com
+	DataCore Software from 2024-03-01
+datacore-tilangovan: datacore-tilangovan!users.noreply.github.com, thulasiraman.ilangovan!datacore.com
+	DataCore Software from 2022-05-01
+datacore-vvarakantham: datacore-vvarakantham!users.noreply.github.com, vandana.varakantham!datacore.com
+	DataCore Software from 2021-01-01
 datadot: datadot!users.noreply.github.com
 	Independent
 datamgmt: davidw!datamgmt.com
@@ -16463,6 +16473,8 @@ dav1x: dav1x!users.noreply.github.com, davis.phillips!gmail.com
 	Red Hat Inc.
 dave-borg: dave-borg!users.noreply.github.com, dborgees!cisco.com
 	Cisco
+dave-brace: dave-brace!users.noreply.github.com, david.brace!datacore.com
+	DataCore Software from 2022-10-01
 dave-dresser: dave_dresser!compuware.com
 	Compuware
 dave-gantenbein: dave-gantenbein!users.noreply.github.com
@@ -23046,9 +23058,10 @@ dsapala: dsapala!users.noreply.github.com
 	Illuminate from 2015-01-01
 dsargent3220: dsargent3220!users.noreply.github.com
 	Independent
-dsavitskiy: dsavitskiy!users.noreply.github.com, kona4kona!gmail.com
+dsavitskiy: dsavitskiy!users.noreply.github.com, kona4kona!gmail.com, dmitry.savitsky!datacore.com
 	Nexenta by DDN until 2021-06-01
-	MayaData Inc. (f/k/a CloudByte Inc) from 2021-06-01
+	MayaData Inc. (f/k/a CloudByte Inc) from 2021-06-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 dsblv: caleb!imakewebthings.com, daraujo!eslsistemas.com.br, disobolev!icloud.com, dsblv!users.noreply.github.com
 	Apple Inc.
 dsbos: dbarclay!savi.com, dsbos!users.noreply.github.com
@@ -23133,6 +23146,8 @@ dshamanthreddy: devagarishamanth!gmail.com, dshamanthreddy!users.noreply.github.
 	Verizon from 2017-01-01 until 2019-02-01
 	Goldman Sachs & Co. LLC from 2019-02-01 until 2022-06-01
 	AWS from 2022-06-01
+dsharma-dc: dsharma-dc!users.noreply.github.com, diwakar.sharma!datacore.com
+	DataCore Software from 2022-12-01
 dsharma283: devesh.sharma!broadcom.com
 	Broadcom Corporation
 dsharp-pivotal: dsharp-pivotal!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -1278,6 +1278,8 @@ edrickwong: edrickwong!users.noreply.github.com, edwong!microsoft.com
 	Independent from 2017-09-01 until 2018-05-01
 	Ascent from 2018-05-01 until 2018-07-01
 	Microsoft Corporation from 2018-07-01
+edrob999: edrob999!users.noreply.github.com, ed.robinson!datacore.com
+	DataCore Software from 2023-09-01
 edsantiago: edsantiago!users.noreply.github.com, santiago!redhat.com
 	Red Hat Inc.
 edsiper: edsiper!gmail.com, edsiper!users.noreply.github.com, eduardo!monkey.io, eduardo!treasure-data.com
@@ -17409,6 +17411,8 @@ hrofiq: hrofiq!users.noreply.github.com
 	Pilar Wahana Artha from 2018-01-01
 hroyrh: hroyrh!users.noreply.github.com
 	Red Hat Inc.
+hrudaya21: hrudaya21!users.noreply.github.com, hrudayaranjan.sahoo!datacore.com
+	DataCore Software from 2023-01-01
 hrw: marcin.juszkiewicz!linaro.org
 	Linaro Limited
 hs0210: hs0210!users.noreply.github.com, hus.fnst!cn.fujitsu.com

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -12937,7 +12937,7 @@ nikwest: github!nikwest.de
 	BlackBerry Limited until 2014-05-01
 	Independent from 2014-05-01 until 2015-03-01
 	Colorimetrix from 2015-03-01
-niladrih: niladrih!users.noreply.github.com, niladri.halder!datacore.com
+niladrih: niladrih!users.noreply.github.com, niladri.halder!datacore.com, niladri.halder26!gmail.com
 	Independent until 2021-02-01
 	MayaData Inc. (f/k/a CloudByte Inc) from 2021-02-01 until 2021-11-01
 	DataCore Software from 2021-11-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -5120,6 +5120,9 @@ milanaleksic: milan!aleksic.dev, milanaleksic!users.noreply.github.com
 	Basware Benelux until 2017-03-01
 	TomTom International B.V. from 2017-03-01 until 2020-01-01
 	Soda from 2020-01-01
+milanhajek: milanhajek!users.noreply.github.com, milan.hajek!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2021-09-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 milanhradil1-tomtom: milanhradil1-tomtom!users.noreply.github.com
 	MeteoGroup until 2017-06-01
 	TomTom International B.V. from 2017-06-01
@@ -12934,9 +12937,9 @@ nikwest: github!nikwest.de
 	BlackBerry Limited until 2014-05-01
 	Independent from 2014-05-01 until 2015-03-01
 	Colorimetrix from 2015-03-01
-niladrih: niladrih!users.noreply.github.com
+niladrih: niladrih!users.noreply.github.com, niladri.halder!datacore.com
 	Independent until 2021-02-01
-	OpenEBS from 2021-02-01 until 2021-11-01
+	MayaData Inc. (f/k/a CloudByte Inc) from 2021-02-01 until 2021-11-01
 	DataCore Software from 2021-11-01
 nilamdyuti: ngoswami!redhat.com, nilamdyuti!gmail.com
 	Red Hat Inc.
@@ -16428,6 +16431,8 @@ orugantichetan: orugantichetan!users.noreply.github.com
 	Independent until 2015-02-01
 	HCL Technologies Ltd. from 2015-02-01 until 2019-04-01
 	Nokia Corporation from 2019-04-01
+orville-wright: orville-wright!users.noreply.github.com, david.brace!datacore.com
+	DataCore Software from 2022-10-01
 orweis: orweis!users.noreply.github.com
 	Malam until 2015-12-01
 	Netline from 2015-12-01 until 2017-10-01
@@ -18571,6 +18576,8 @@ pchan: pchan!users.noreply.github.com, prasad.chand!gmail.com, prasadc!vmware.co
 	NVIDIA Corporation until 2018-05-01
 	Intel Corporation from 2018-05-01 until 2020-12-01
 	VMware Inc. from 2020-12-01
+pchandra19: pchandra19!users.noreply.github.com, prateek.chandra!datacore.com
+	DataCore Software from 2020-07-01
 pchila: paolo.chila!dynatrace.com
 	Amadeus until 2016-04-01
 	VASCO from 2016-04-01 until 2017-03-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -194,6 +194,8 @@ r0ushann: r0ushann!users.noreply.github.com
 r1chardj0n3s: r1chardj0n3s!gmail.com
 	Rackspace until 2017-04-28
 	Independent from 2017-04-28
+r1jt: r1jt!users.noreply.github.com, ranjith.mp!datacore.com
+	DataCore Software from 2022-09-01
 r2d4: m!rickard.email, mrick!google.com, r2d4!users.noreply.github.com
 	Blackstone Group L.P. until 2016-01-01
 	Google LLC from 2016-01-01 until 2019-01-01
@@ -5605,6 +5607,9 @@ roguishmountain: paulofelipe.feitosa!gmail.com, roguishmountain!gmail.com, samsc
 	Microsoft Corporation
 rohan-kulkarni-25: rohan-kulkarni-25!users.noreply.github.com, rohank2502!gmail.com
 	Independent
+rohan2794: rohan2794!users.noreply.github.com, rohan.kumar!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-02-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 rohan47: rohan47!users.noreply.github.com, rohanrgupta1996!gmail.com, rohgupta!redhat.com
 	Independent until 2016-01-01
 	Fractalio Data from 2016-01-01 until 2017-02-01
@@ -15144,6 +15149,8 @@ singhmeghna79: meghna.singh!mayadata.io, singhmeghna79!gmail.com, singhmeghna79!
 	Hitachi Vantara LLC from 2020-04-01
 singlemocha: singlemocha!hotmail.com
 	Samsung SDS
+sinhaashish: sinhaashish!users.noreply.github.com, ashish.sinha!datacore.com
+	DataCore Software from 2022-09-01
 sinkingpoint: colin!quirl.co.nz, sinkingpoint!users.noreply.github.com
 	Cloudflare Inc
 sinsharat: sharat.singh!huawei.com, sinsharat!gmail.com, sinsharat!users.noreply.github.com

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -1474,8 +1474,9 @@ tiagodeoliveira: tiago!tiago.sh
 	PayU Payments Private Limited from 2017-03-01 until 2018-03-01
 	OSRAM SYLVANIA Inc from 2018-03-01 until 2018-09-01
 	Mercedes-Benz.io from 2018-09-01
-tiagolobocastro: tiago.castro!mayadata.io, tiagolobocastro!gmail.com tiagolobocastro!users.noreply.github.com, tiagolobocastro!users.noreply.github.com
-	MayaData Inc. (f/k/a CloudByte Inc)
+tiagolobocastro: tiago.castro!mayadata.io, tiagolobocastro!gmail.com tiagolobocastro!users.noreply.github.com, tiago.castro!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-02-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 tiagomeireles: tiagomeireles!users.noreply.github.com
 	Independent until 2017-10-01
 	Red Hat Inc. from 2017-10-01
@@ -9759,10 +9760,9 @@ w1ndy: mystery.wd!gmail.com, w1ndy!users.noreply.github.com
 	Independent from 2019-09-01
 w1nte: w1nte!users.noreply.github.com
 	Independent
-w3aman: aman.gupta!mayadata.io, w3aman!users.noreply.github.com
-	Independent until 2018-05-01
-	Indian Railways (South East Central) from 2018-05-01 until 2018-06-01
-	MayaData Inc. (f/k/a CloudByte Inc) from 2018-06-01
+w3aman: aman.gupta!mayadata.io, w3aman!users.noreply.github.com aman.gupta!datacore.com
+	MayaData Inc. (f/k/a CloudByte Inc) from 2019-07-01 until 2021-11-01
+	DataCore Software from 2021-11-01
 w3st3ry: w3st3ry!users.noreply.github.com
 	PulseHeberg until 2015-09-01
 	Independent from 2015-09-01 until 2016-07-01


### PR DESCRIPTION
Updating affiliation for employees who currently work for CNCF OpenEBS project, and belong to DataCore Software, and previously MayaData Inc.