### PR TITLE
Update affiliation for astencel-sumo

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -20809,7 +20809,8 @@ astelmashenko: astelmashenko!users.noreply.github.com
 	viax from 2019-08-01
 astencel-sumo: astencel!sumologic.com, astencel-sumo!users.noreply.github.com
 	Independent until 2020-09-01
-	Sumo Logic Inc. from 2020-09-01
+	Sumo Logic Inc. from 2020-09-01 until 2024-04-30
+	Independent from 2024-05-01
 asterite: acidjazz!gmail.com, asterite!gmail.com, asterite!users.noreply.github.com, ninaolofs!gmail.com
 	Manas until 2017-05-01
 	Citrusbyte from 2017-05-01 until 2019-03-01


### PR DESCRIPTION
I have used the `astencel-sumo` GitHub account at Sumo Logic between September 2020 and April 2024. After that, I have **renamed** the GitHub account `astencel-sumo` to `andrzej-stencel` and started working for Elastic from May 2024. This is already reflected in the `andrzej-stencel` affiliation.