### PR TITLE
Updated Akuity and Argo Project affiliations

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -10503,7 +10503,7 @@ agilgur5: agilgur5!gmail.com, agilgur5!users.noreply.github.com
 	Various until 2020-03-01
 	NS8 Inc from 2020-03-01 until 2020-09-01
 	Independent from 2020-09-01 until 2020-12-01
-	Capital One from 2020-12-01
+	Capital One from 2020-12-01 until 2023-10-01
 agill17: agill17!users.noreply.github.com, amgill1234!gmail.com
 	Independent until 2016-07-01
 	Fidelis Cybersecurity from 2016-07-01 until 2016-12-01
@@ -13615,7 +13615,7 @@ alexminder: alexminder!users.noreply.github.com
 	RT Labs until 2015-01-01
 	Rostelecom from 2015-01-01 until 2018-12-01
 	RBK.money from 2018-12-01
-alexmt: alexander_matyushentsev!intuit.com, alexmt!users.noreply.github.com, amatyushentsev!gmail.com
+alexmt: alexander_matyushentsev!intuit.com, alexmt!users.noreply.github.com, amatyushentsev!gmail.com, alex!akuity.io, alexander!akuity.io
 	EPAM Systems Inc until 2014-10-01
 	Ooyala from 2014-10-01 until 2015-10-01
 	FirstRain from 2015-10-01 until 2016-08-01
@@ -18384,12 +18384,13 @@ anubhabMajumdar: anubhabMajumdar!users.noreply.github.com
 	Microsoft Corporation from 2022-09-01
 anubhakushwaha: anu.kushwaha1211!gmail.com, anubha_bt2k14!dtu.ac.in, anubhakushwaha!users.noreply.github.com
 	Independent
-anubhav06: anubhav06!users.noreply.github.com, mail.anubhav06!gmail.com
+anubhav06: anubhav!akuity.io, anubhav06!users.noreply.github.com, mail.anubhav06!gmail.com, anubhav06!users.noreply.github.com
 	Independent until 2022-01-01
 	MLH Fellowship from 2022-01-01 until 2022-02-01
 	Independent from 2022-02-01 until 2022-06-01
 	Sarg from 2022-06-01 until 2022-07-01
-	BVPIEEE from 2022-07-01
+	BVPIEEE from 2022-07-01 until 2024-04-28
+	Akuity Inc. from 2024-04-29
 anubhavmishra: anubhavmishra!me.com, anubhavmishra!users.noreply.github.com, mishra!hashicorp.com
 	Hootsuite until 2017-11-01
 	HashiCorp Inc from 2017-11-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -3123,7 +3123,7 @@ blakeembrey: blakeembrey!users.noreply.github.com, hello!blakeembrey.com, nerd.c
 	Opendoor Labs Inc from 2017-09-01
 blakelapierre: blakelapierre!gmail.com, blakelapierre!users.noreply.github.com
 	Independent
-blakepettersson: blakepettersson!users.noreply.github.com
+blakepettersson: blake!akuity.io, blakepettersson!users.noreply.github.com
 	Krobier until 2024-02-01
 	Akuity Inc. from 2024-02-01
 blakeroberts-wk: blake.roberts!workiva.com, blakeroberts-wk!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -15702,6 +15702,7 @@ hanwgyu: han.wgyu!gmail.com, hanwgyu!users.noreply.github.com
 hanxiaop: hanxiaop!google.com, hanxiaop!usc.edu, hanxiaop!users.noreply.github.com, hanxiaop8!gmail.com, hanxiaop8!outlook.com, michael.han!daocloud.io, xiaopeng!akuity.io, xiaopeng.han-iog!daocloud.io
 	Independent until 2021-03-08
 	DaoCloud Network Technology Co. Ltd. from 2021-03-08 until 2024-05-05
+	Akuity Inc. from 2024-06-05
 hanxiaoshuai: 30897305+hanxiaoshuai!users.noreply.github.com, hangaoshuai1!huawei.com, hanxiaoshuai!users.noreply.github.com
 	Huawei Technologies Co. Ltd
 hanxie-crypto: hanxie-crypto!users.noreply.github.com, hanxie.wq!alibaba-inc.com
@@ -17339,10 +17340,11 @@ hicqu: hicqu!users.noreply.github.com, onlyqupeng!gmail.com, qupeng!pingcap.com
 hidai: hidai!users.noreply.github.com
 	Google LLC until 2018-10-01
 	Preferred Networks Inc. from 2018-10-01
-hiddeco: 10063039+hiddeco!users.noreply.github.com, hello!hidde.co, hidde!hhh.computer, hidde!weave.works, hiddeco!users.noreply.github.com
+hiddeco: hidde!akuity.io, 10063039+hiddeco!users.noreply.github.com, hello!hidde.co, hidde!hhh.computer, hidde!weave.works, hiddeco!users.noreply.github.com
 	Tree House NL until 2019-02-08
 	Weaveworks Inc. from 2019-02-08 until 2024-01-29
-	Independent from 2024-01-29
+	Independent from 2024-01-29 until 2024-02-19
+	Akuity Inc. from 2024-02-20
 hideakiaoyagi: hideakiaoyagi!users.noreply.github.com
 	Independent until 2017-07-01
 	AWS from 2017-07-01
@@ -19004,6 +19006,8 @@ hwq830: weiqi.hwq!alibaba-inc.com
 	Jd.Com until 2014-08-01
 	Dalian Wanda Group from 2014-08-01 until 2016-09-01
 	Jd.Com from 2016-09-01
+hwwn: hwwn!live.com, haowen!akuity.io, hwwn!users.noreply.github.com
+	Akuity Inc. from 2024-04-29
 hwyan: Haowei.Yan!spirent.com, hwyan!users.noreply.github.com
 	Spirent Communications Inc
 hxy88888: hanxiangyuan!jd.com
@@ -20978,6 +20982,8 @@ imuqtadir: imuqtadir!users.noreply.github.com
 	AWS from 2015-05-01 until 2015-08-01
 	Independent from 2015-08-01 until 2016-02-01
 	AWS from 2016-02-01
+imwithye: imwithye!gmail.com, yiwei!akuity.io, imwithye!users.noreply.github.com
+	Akuity Inc. from 2024-05-20
 imyashvinder: imyashvinder!users.noreply.github.com
 	Unmukti until 2015-06-01
 	IndiaMART InterMESH from 2015-06-01 until 2016-10-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -2703,7 +2703,7 @@ jessesleeping: jessesleeping!users.noreply.github.com, jiexil!fb.com
 	Meta Platforms Inc. from 2017-02-01
 jessestuart: alanspurlock!hotmail.com, hi!jessestuart.com, jdstuart!icloud.com, jessestuart!users.noreply.github.com
 	Apple Inc.
-jessesuen: jessesuen!gmail.com, jessesuen!users.noreply.github.com
+jessesuen: jessesuen!gmail.com, jessesuen!users.noreply.github.com, jesse!akuity.io
 	TINTRI BY DDN INC until 2016-03-01
 	Applatix from 2016-03-01 until 2018-01-01
 	Intuit Inc. from 2018-01-01 until 2022-08-01
@@ -9145,6 +9145,8 @@ junyazhang: junyazhang!users.noreply.github.com
 	Google LLC from 2020-09-01 until 2020-11-01
 	Independent from 2020-11-01 until 2021-06-01
 	Google LLC from 2021-06-01
+junzebao: junzebao!gmail.com, junze!akuity.io, junzebao!users.noreply.github.com
+	Akuity Inc. from 2024-04-15
 juozasg: juozasg!users.noreply.github.com, juozasgaigalas!gmail.com
 	Weaveworks Inc.
 jupblb: jupblb!google.com, jupblb!users.noreply.github.com

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -7618,7 +7618,7 @@ ropnop: rflathers!gmail.com
 	Independent from 2018-09-01 until 2019-02-01
 	Motorola Mobility Inc. from 2019-02-01 until 2020-08-01
 	Marqeta from 2020-08-01
-ropsii: perovic.petar!gmail.com
+ropsii: perovic.petar!gmail.com, petar!akuity.io
 	Active Collab until 2015-09-01
 	Independent from 2015-09-01 until 2015-12-01
 	Super from 2015-12-01 until 2016-05-01

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -11650,7 +11650,7 @@ wanghaoran1988: haowang!redhat.com, wanghaoran1988!users.noreply.github.com
 	Red Hat Inc. from 2015-07-01
 wanghh2000: haihwang!cn.ibm.com, wanghh2000!163.com, wanghh2000!users.noreply.github.com
 	NetEase Inc
-wanghong230: wanghong230!users.noreply.github.com
+wanghong230: wanghong230!users.noreply.github.com, hong!akuity.io
 	TINTRI BY DDN INC until 2016-04-01
 	Applatix from 2016-04-01 until 2017-04-01
 	Springpath from 2017-04-01 until 2018-04-01
@@ -13565,6 +13565,8 @@ wojtekmach: wojtekmach!users.noreply.github.com
 	ClubCollect from 2016-04-01 until 2018-08-01
 	Plataformatec from 2018-08-01 until 2020-01-01
 	Dashbit from 2020-01-01
+wojtekidd: wojtekidd!users.noreply.github.com, wojtek!akuity.io
+	Akuity Inc. from 2022-01-01
 wokalski: me!wczekalski.com
 	Macoscope until 2014-12-01
 	Uberchord Engineering from 2014-12-01 until 2017-07-01


### PR DESCRIPTION
This PR has two basic changes

* Updated Akuity affiliations for new engineers that have joined our org
* Updated `agilgur5` affiliation as [they are no longer working at CapitalOne](https://www.linkedin.com/in/agilgur5/)