### PR TITLE
Fix mixing of CoreOS and Redhat affilications

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -14256,7 +14256,7 @@ crash-utility: anderson!redhat.com
 crassirostris: crassirostris!yandex.com
 	Google LLC
 crawford: alex.crawford!coreos.com, crawford!users.noreply.github.com
-	Red Hat Inc.
+	CoreOS Inc.
 crazoes: shreeya.patel23498!gmail.com
 	Independent
 crazy-canux: canuxcheng!gmail.com, crazy-canux!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -7040,7 +7040,8 @@ fangzhengjin: fangzhengjin!gmail.com, fangzhengjin!users.noreply.github.com
 	Automobile Comercio De Pecas Ltda
 fanminshi: fanmin.shi!coreos.com, fanmin.shi!gmail.com, fanminshi!users.noreply.github.com
 	Amazon until 2016-08-01
-	Red Hat Inc. from 2016-08-01 until 2018-10-01
+	CoreOS Inc. from 2016-08-01 until 2018-02-01
+	Red Hat Inc. from 2018-02-01 until 2018-10-01
 	Argo AI LLC from 2018-10-01 until 2019-05-01
 	Independent from 2019-05-01
 fanndu: fanndu!users.noreply.github.com
@@ -15445,7 +15446,7 @@ gytisgreitai: gytisgreitai!users.noreply.github.com
 gyuho: gyuho!users.noreply.github.com, gyuhox!gmail.com, leegyuho!amazon.com
 	Independent until 2014-04-01
 	System1 from 2014-04-01 until 2015-12-01
-	Red Hat Inc. from 2015-12-01 until 2018-08-01
+	CoreOS Inc. from 2015-12-01 until 2018-08-01
 	Amazon from 2018-08-01 until 2021-10-01
 	Ava Labs from 2021-10-01 until 2023-07-01
 	TBA from 2023-07-01
@@ -17679,7 +17680,7 @@ heyfey: heyfey!users.noreply.github.com, tsungtsohsieh!gmail.com
 heyingstar: heyingbj!inspur.com
 	Inspur Group
 heyitsanthony: anthony.romano!coreos.com, heyitsanthony!users.noreply.github.com, romanoanthony061!gmail.com
-	Red Hat Inc.
+	CoreOS Inc.
 heyjared: heyjared!users.noreply.github.com, jared.sim!me.com
 	Singapore Ministry of Defence until 2014-08-01
 	Independent from 2014-08-01 until 2016-05-01
@@ -18452,7 +18453,7 @@ hongbin: hongbin034!gmail.com
 hongchaodeng: fengjingchao!gmail.com, hongchaodeng!users.noreply.github.com, hongchaodeng1!gmail.com
 	Adobe Inc. until 2013-09-01
 	Cloudera Inc. from 2013-09-01 until 2015-11-01
-	Red Hat Inc. from 2015-11-01 until 2018-03-01
+	CoreOS Inc. from 2015-11-01 until 2018-03-01
 	Alibaba Group from 2018-03-01 until 2022-04-01
 	Helium Systems Inc. from 2022-04-01 until 2023-09-01
 	CNCF from 2023-09-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -6931,7 +6931,7 @@ jonbonazza: jonbonazza!gmail.com, jonbonazza!users.noreply.github.com
 	Epic Games Inc from 2019-11-01
 jonboulle: jon!twitter.com, jonathan.boulle!coreos.com, jonathanboulle!gmail.com, jonboulle!users.noreply.github.com
 	Twitter Inc. until 2014-03-01
-	Red Hat Inc. from 2014-03-01 until 2018-02-01
+	CoreOS Inc. from 2014-03-01 until 2018-02-01
 	NStack from 2018-02-01 until 2018-07-01
 	Blinkist from 2018-07-01 until 2019-08-01
 	Independent from 2019-08-01 until 2021-01-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -21894,7 +21894,8 @@ philippt: philippt!users.noreply.github.com
 	Virtual Ops LLP
 philips: bphilips!redhat.com, brandon!ifup.co, brandon!ifup.org, brandon.philips!coreos.com, philips!users.noreply.github.com
 	Rackspace Hosting until 2013-02-01
-	Red Hat Inc. from 2013-02-01
+	CoreOS Inc. from 2013-02-01 until 2018-02-01
+	Red Hat Inc. from 2018-02-01
 philipsparrow: philipsparrow!users.noreply.github.com
 	Magor until 2017-05-01
 	Trend Micro Incorporated from 2017-05-01 until 2018-09-01

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -15482,7 +15482,7 @@ xialonglee: li.xialong!zte.com.cn, xialonglee!users.noreply.github.com
 xiang17: xiang17!users.noreply.github.com, xili9!microsoft.com
 	Microsoft Corporation
 xiang90: xiang.li!coreos.com, xiang90!users.noreply.github.com, xiangli.cs!gmail.com
-	Red Hat Inc. until 2018-02-01
+	CoreOS Inc. until 2018-02-01
 	Alibaba Group from 2018-02-01 until 2021-05-01
 	Meta Platforms Inc. from 2021-05-01 until 2022-11-01
 	Uber from 2022-11-01


### PR DESCRIPTION
In preparation for etcd project journey report I have looked at the contribution data for the project.
I was surprised to not only to not find CoreOS in list of companies, but also most of their core contributors being affiliated to RedHat. 

Given that CoreOS had a substantial contributor base prior to the acquisition, it raises questions about how contributions are tracked and attributed after such mergers. Does this practice of consolidating contributions under the acquiring company accurately reflect the diverse contributions within the open-source ecosystem? Should we be encouraging the trend of large corporations acquiring startups as a means to bolster their own contribution metrics?

This PR restores affiliations to CoreOS for top etcd contributors. Changes are based on:
* Linkedin profiles that I was able to find (can provide a list)
* Fact that acquisition happen on Feb 1, 2018 
* Usage of CoreOS email domain and lack of contributions post 2018