### PR TITLE
Add Kubermatic employees and update Company name from Loodse

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -3725,6 +3725,8 @@ ArchiFleKs: ArchiFleKs!users.noreply.github.com, github!daniel.goulder.name, lef
 	Kiln from 2019-12-01
 Archimedes-Dear: Archimedes-Dear!users.noreply.github.com
 	DaoCloud Network Technology Co. Ltd.
+Archups: archupsawant!gmail.com
+    Kubermatic GmbH from 2024-10-01
 ArcoKim: arcomade12!gmail.com
 	Independent
 ArcticSnowman: ArcticSnowman!users.noreply.github.com, steven.arnott!grantstreet.com
@@ -7750,6 +7752,8 @@ Dakshjain1: Dakshjain1!users.noreply.github.com
 	Zscaler from 2024-05-01
 Dakuan: Dakuan!users.noreply.github.com, dom!dombarker.co.uk
 	Independent
+Dakraus: mr.dk!gmx.de
+    Kubermatic GmbH from 2021-11-15
 Dakyne: Dakyne!users.noreply.github.com
 	Saucisson
 DaleBingham: dalebingham!users.noreply.github.com
@@ -8765,6 +8769,8 @@ DharmitD: DharmitD!users.noreply.github.com
 	Independent from 2020-05-01 until 2020-07-01
 	iRobot from 2020-07-01 until 2020-12-01
 	Red Hat Inc. from 2020-12-01
+Dharapvj: dharapvj!gmail.com, vijay!kubermatic.com
+    Kubermatic GmbH from 2021-03-15
 Dhaval08: Dhaval08!users.noreply.github.com, shahdhaval1893!gmail.com
 	Electronic Arts Inc.
 DheerajSShetty: DheerajSShetty!users.noreply.github.com
@@ -15978,6 +15984,8 @@ JuliusSweetland: JuliusSweetland!users.noreply.github.com
 	Goldman Sachs & Co. LLC until 2015-02-01
 	CME from 2015-02-01 until 2016-08-01
 	Arrowgrass Capital Partners from 2016-08-01
+Julioc-p: 14-10820!usb.ve
+    Kubermatic GmbH from 2024-10-01
 Jummit: Jummit!users.noreply.github.com
 	Walmart Inc.
 JunPiaoHW: piaojun!huawei.com
@@ -16924,6 +16932,8 @@ Kokkini: Kokkini!users.noreply.github.com, trannhatquang1104!gmail.com
 	Independent from 2020-04-01 until 2020-06-01
 	VantaForce from 2020-06-01 until 2021-06-01
 	BelleTorus from 2021-06-01
+Koksay: koray.oksay!gmail.com, koray!kubermatic.com
+    Kubermatic GmbH from 2021-05-01
 KoltesDigital: KoltesDigital!users.noreply.github.com, bloutiouf!gmail.com
 	Independent until 2015-10-01
 	Rubika from 2015-10-01 until 2015-12-01
@@ -19873,6 +19883,8 @@ Mexx77: Mexx77!users.noreply.github.com
 Meyazhagan: meyazhagan.ofcl!gmail.com
 	Independent until 2022-01-01
 	Eutech Cybernetic from 2022-01-01
+Mfahlandt: mfahlandt!pixel-haufen.de, m!pixel-haufen.de, dasyoshi!gmail.com, mario!kubermatic.com
+    Kubermatic GmbH from 2020-10-01
 MiLk: MiLk!users.noreply.github.com, emilien!kkvesper.jp, hello!emilienkenler.com
 	TableCheck
 MiaoZhou: miaozhou!users.noreply.github.com, millsonzhou!gmail.com
@@ -20102,6 +20114,8 @@ MikaelSmith: MikaelSmith!users.noreply.github.com, michael.smith!puppetlabs.com
 	Puppet Inc.
 MikaelSmith: mike!sticknet.net
 	WPEngine Inc.
+Mihiragrawal: mihiragrawal1!gmail.com
+    Kubermatic GmbH from 2021-05-10
 MikailBag: MikailBag!users.noreply.github.com, bagishov.mikail!yandex.ru, bagishov444.2002.02!gmail.com
 	YANDEX LLC
 Mike-Landers: Mike-Landers!users.noreply.github.com
@@ -20450,6 +20464,8 @@ MohammedAdain: mwadain!gmail.com
 	Independent until 2020-06-01
 	EdSoft from 2020-06-01 until 2020-12-01
 	Arcesium from 2020-12-01
+Mohamed-rafraf: mohamedrafraf99!gmail.com, mohamedrafraf!insat.u-carthage.tn
+    Kubermatic GmbH from 2024-02-01
 Mohdcode: Mohdcode!users.noreply.github.com
 	Independent
 Mohiit70: mail.mohitbisht!gmail.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -1987,6 +1987,8 @@ RoniSegal: roni!sealights.io, roni!sealihts.io
 	The Israel Defense Forces until 2016-03-01
 	Tomia Inc. from 2016-03-01 until 2017-02-01
 	Sealights Technologies Ltd from 2017-02-01
+Ronissac88: ronissac88!gmail.com
+    Kubermatic from 2024-01-01
 RonnyLV: hamste126!gmail.com
 	SIA Autentica until 2018-11-01
 	Lokalise from 2018-11-01
@@ -4293,6 +4295,8 @@ Sodki: Sodki!users.noreply.github.com, henrique.rodrigues!ist.utl.pt
 Sodman: Sodman!users.noreply.github.com, shane!shaneod.net, shane.odonnell!solo.io, sodman74!gmail.com
 	Independent until 2020-05-26
 	Solo.io from 2020-05-26
+Soer3n: srenhenning!gmail.com
+    Kubermatic GmbH from 2024-12-01
 SoftMemes: kristian!softmemes.com
 	Google LLC until 2016-04-01
 	Elder from 2016-04-01 until 2022-06-01
@@ -12292,6 +12296,8 @@ adodon2go: adodon!cisco.com
 	Luxoft
 adohe: coolhzb!163.com
 	Alibaba Group
+Adoi: adonismurati!gmail.com, adonis!kubermatic.com
+    Kubermatic GmbH from 2024-11-01
 adolphlwq: adolphlwq!users.noreply.github.com, kenan3015!gmail.com
 	DuoHuo
 adonaicosta: adonai.costa!gmail.com, adonaicosta!users.noreply.github.com
@@ -13581,7 +13587,8 @@ ahmedwaleedmalik: ahmedwaleedmalik!users.noreply.github.com, waleed!stakater.com
 	Independent from 2015-08-01 until 2016-12-01
 	Bentley Motors Limited from 2016-12-01 until 2018-07-01
 	Aurora from 2018-07-01 until 2019-07-01
-	Stakater AB from 2019-07-01
+	Stakater AB from 2019-07-01  until 2021-10-10
+    Kubermatic GmbH from 2021-10-11
 ahmelsayed: ahmed!elsayed.io, ahmels!microsoft.com
 	Microsoft Corporation
 ahmet-uyar: ahmet-uyar!users.noreply.github.com
@@ -17559,7 +17566,7 @@ alvaroaleman: alv2412!googlemail.com, alvaroaleman!users.noreply.github.com
 	Silpion from 2015-01-01 until 2017-04-01
 	inovex GmbH from 2017-04-01 until 2017-09-01
 	Zeus Holding Market Ltd. from 2017-09-01 until 2018-01-01
-	Loodse from 2018-01-01 until 2020-01-01
+	Kubermatic GmbH from 2018-01-01 until 2020-01-01
 	Red Hat Inc. from 2020-01-01 until 2022-09-01
 	Confluent from 2022-09-01
 alvarobacelar: alvarobacelar!users.noreply.github.com, alvarobsttl!gmail.com

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -13722,6 +13722,7 @@ chaoqin-li1123: chaoqin-li1123!users.noreply.github.com
 chaosaffe: chaosaffe!users.noreply.github.com, jason!chaosaffe.io, jason!loodse.com, kyle!pyrus.io
 	Talk Shop until 2016-02-01
 	International Business Machines Corporation from 2016-02-01
+	Kubermatic GmbH from 2016-09-01 until 2018-02-01
 chaosi-zju: chaosi!zju.edu.cn, chaosi-zju!users.noreply.github.com, panchaosi!huawei.com
 	Huawei Technologies Co. Ltd
 chaospuppy: chaospuppy!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -13906,7 +13906,7 @@ florath: florath!users.noreply.github.com
 floreks: floreks!users.noreply.github.com, madewokherd!gmail.com, s.florek91!gmail.com, sebastian.florek!loodse.com, sebastian.florek!ts.fujitsu.com
 	Transition Technologies until 2015-04-15
 	Fujitsu Limited from 2015-04-15 until 2018-11-01
-	Loodse from 2018-11-01 until 2022-06-01
+	Kubermatic GmbH from 2018-11-01 until 2022-06-01
 	Plural from 2022-06-01
 florent-vial: florent.vial!intel.com
 	Intel Corporation
@@ -21041,7 +21041,7 @@ guusdk: guus!goodbytes.nl, guus.der.kinderen!gmail.com, guusdk!users.noreply.git
 guusvw: guus!loodse.com, guus!van.weelden.de, guusvw!users.noreply.github.com
 	veeseo until 2017-01-01
 	Ligatus from 2017-01-01 until 2017-07-01
-	Loodse from 2017-07-01 until 2019-02-01
+	Kubermatic GmbH from 2017-07-01 until 2019-02-01
 	MOIA from 2019-02-01
 guxlightyear: guxlightyear!users.noreply.github.com
 	Ratio Technology

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -3797,7 +3797,7 @@ infinitydon: infinitydon!users.noreply.github.com
 	Ericsson until 2017-11-01
 	Independent from 2017-11-01 until 2018-01-01
 	Clouds Sky GmbH from 2018-01-01 until 2019-06-01
-	Loodse from 2019-06-01
+	Kubermatic GmbH from 2019-06-01
 influx6: alex.ewetumo!gmail.com
 	Independent until 2018-12-01
 	Lalamove from 2018-12-01 until 2019-03-01
@@ -22842,8 +22842,8 @@ krol3: guillen.carolina!gmail.com, krol3!users.noreply.github.com
 	Elasticsearch Inc. from 2022-12-01
 krolson: krolson!microsoft.com
 	Microsoft Corporation
-kron4eg: kron4eg!users.noreply.github.com, kron82!gmail.com
-	Independent
+kron4eg: kron4eg!users.noreply.github.com, kron82!gmail.com, artiom!hey.com, artiom!kubermatic.com
+    Kubermatic GmbH from 2018-03-01
 kronin: kronin!users.noreply.github.com
 	Catholic Health Initiatives until 2016-09-01
 	AWS from 2016-09-01 until 2017-07-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -6242,7 +6242,7 @@ maci0: maci.stgn!gmail.com, maci0!users.noreply.github.com
 maciaszczykm: m9k.tech!gmail.com, maciaszczykm!icloud.com, maciaszczykm!users.noreply.github.com, marcin.maciaszczyk!ts.fujitsu.com
 	Transition Technologies until 2015-06-15
 	Fujitsu Limited from 2015-06-15 until 2018-09-01
-	Loodse from 2018-09-01 until 2022-06-01
+	Kubermatic GmbH from 2018-09-01 until 2022-06-01
 	Plural from 2022-06-01
 maciej: maciej.bilas!gmail.com
 	Cloudflare Inc
@@ -13002,7 +13002,7 @@ mfrances17: mfrances17!users.noreply.github.com
 mfranczy: mfranczy!redhat.com, mfranczy!users.noreply.github.com
 	Akamai Technologies Inc. until 2017-04-01
 	Red Hat Inc. from 2017-04-01 until 2019-10-01
-	Loodse from 2019-10-01
+	Kubermatic GmbH from 2019-10-01
 mfriedenhagen: mfriedenhagen!gmail.com, mfriedenhagen!users.noreply.github.com, mirko.friedenhagen!1und1.de
 	United Internet AG until 2014-05-01
 	1&1 Mail & Media from 2014-05-01
@@ -18003,7 +18003,7 @@ mr-yaky: mr-yaky!users.noreply.github.com
 mrIncompetent: henrik!henrik-schmidt.de, henrik!loodse.com, mrIncompetent!users.noreply.github.com
 	trigonon until 2015-08-01
 	ABOUT YOU from 2015-08-01 until 2016-10-01
-	Loodse from 2016-10-01 until 2019-09-01
+	Kubermatic GmbH from 2016-10-01 until 2019-09-01
 	Confluent from 2019-09-01 until 2023-11-01
 	Qdrant from 2023-11-01
 mrSingh007: mrSingh007!users.noreply.github.com
@@ -23101,7 +23101,7 @@ nikhita: hello!nikhita.dev, nikhita!users.noreply.github.com, nikitaraghunath!gm
 	Independent until 2017-12-01
 	Red Hat Inc. from 2017-12-01 until 2018-06-01
 	Independent from 2018-06-01 until 2018-10-01
-	Loodse from 2018-10-01 until 2020-03-01
+	Kubermatic GmbH from 2018-10-01 until 2020-03-01
 	VMware Inc. from 2020-03-01
 nikhleshgoenka: nikhileshgoenka!gmail.com
 	Radarr until 2015-12-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -3730,7 +3730,7 @@ p0bailey: p0bailey!users.noreply.github.com
 p0lyn0mial: lukasz.szaszkiewicz!gmail.com, p0lyn0mial!users.noreply.github.com
 	Intel Corporation until 2014-12-01
 	Adtoma from 2014-12-01 until 2018-01-01
-	Loodse from 2018-01-01 until 2019-06-01
+	Kubermatic GmbH from 2018-01-01 until 2019-06-01
 	Red Hat Inc. from 2019-06-01
 p0tr3c: p0tr3c!users.noreply.github.com
 	Schneider Electric until 2014-09-01
@@ -11984,7 +11984,8 @@ raja-sekhar-r: raja-sekhar-r!users.noreply.github.com
 rajaSahil: rajaSahil!users.noreply.github.com, sahil.raja!mayadata.io
 	Independent until 2018-08-01
 	HackerRank from 2018-08-01 until 2020-05-01
-	MayaData Inc. (f/k/a CloudByte Inc) from 2020-05-01
+	MayaData Inc. (f/k/a CloudByte Inc) from 2020-05-01 until 2024-10-31
+    Kubermatic GmbH from 2024-11-01
 rajagopalanand: rajagopalanand!users.noreply.github.com
 	Independent until 2021-04-01
 	AWS from 2021-04-01
@@ -13636,7 +13637,7 @@ realandersn: realandersn!users.noreply.github.com
 realdimas: realdimas!users.noreply.github.com
 	Independent
 realfake: luk.burchard!gmail.com, realfake!users.noreply.github.com
-	Loodse
+	Kubermatic GmbH
 realgeorgewu: 270633542!qq.com
 	Independent until 2016-07-01
 	CHINA CITIC BANK from 2016-07-01 until 2016-08-01
@@ -22295,7 +22296,7 @@ schatekar: schatekar!users.noreply.github.com, suhas.chatekar!gmail.com
 schauerte: schauerte!users.noreply.github.com
 	Independent
 scheeles: scheele.s!web.de, scheeles!loodse.com, scheeles!users.noreply.github.com, sebastian!loodse.com
-	Loodse
+	Kubermatic GmbH from 2016-01-01
 scheler: santosh.cheler!appdynamics.com, santosh.cheler!gmail.com, scheler!cisco.com, scheler!users.noreply.github.com
 	Independent until 2020-06-01
 	Cisco from 2020-06-01

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -3190,8 +3190,8 @@ xroche: roche!httrack.com
 	Scality Inc. from 2015-07-01
 xrow: xrow!users.noreply.github.com
 	xrow
-xrstf: christoph!kubermatic.com, git!xrstf.de, xrstf!users.noreply.github.com
-	Loodse
+xrstf: christoph!kubermatic.com, git!xrstf.de, xrstf!users.noreply.github.com, github!xrstf.de
+	Kubermatic GmbH from 2018-08-01
 xs3c: w90p710!gmail.com, xs3c!users.noreply.github.com
 	Independent until 2019-07-01
 	知小白信息技术有限公司 from 2019-07-01 until 2019-09-01


### PR DESCRIPTION
Update all current Engineers of Kubermatic to fix affiliation 
Update past Employees to Kubermatic GmbH instead of Loodse as the Company changed names.
Source: [Source](https://techcrunch.com/2020/06/17/loodse-becomes-kubermatic-and-open-sources-kubernetes-automation-platform/)