### PR TITLE
Update my affiliation and fix dates for previous affiliation

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -11108,8 +11108,9 @@ stormqueen1990: 698465+stormqueen1990!users.noreply.github.com, mauren.berti!cha
 	Independent until 2019-06-01
 	VMware Inc. from 2019-06-01 until 2022-10-07
 	SUSE LLC from 2022-10-07 until 2023-05-05
-	Independent from 2023-05-05 until 2023-07-31
-	Chainguard Inc. from 2023-07-31
+	Independent from 2023-05-05 until 2023-08-01
+	Chainguard Inc. from 2023-08-01 until 2024-07-26
+	Independent from 2024-07-26
 storozhilov: storozhilov!users.noreply.github.com
 	EPAM Systems Inc until 2015-11-01
 	Crossover for Work from 2015-11-01 until 2016-03-01


### PR DESCRIPTION
Update my current affiliation and fix dates for the previous one (should be August 1st, 2023 instead of July 31st, 2023).