### PR TITLE
fix: github rename from agaudreault-jive to agaudreault

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -13717,13 +13717,14 @@ agau4779: agau4779!gmail.com, agau4779!users.noreply.github.com, gau!google.com
 	Independent from 2017-11-01 until 2018-01-01
 	Google LLC from 2018-01-01 until 2021-03-01
 	Clever from 2021-03-01
-agaudreault-jive: agaudreault-jive!users.noreply.github.com
+agaudreault: agaudreault-jive!users.noreply.github.com, agaudreault!users.noreply.github.com, alexandre_gaudreault!intuit.com, alexandre.gaudreault!goto.com, alexandre.gaudreault!logmein.com
 	Ubisoft until 2014-12-01
 	Independent from 2014-12-01 until 2015-05-01
 	Genetec from 2015-05-01 until 2015-08-01
 	Independent from 2015-08-01 until 2016-05-01
 	Genetec from 2016-05-01 until 2019-02-01
-	LOGMEIN INC. from 2019-02-01
+	LOGMEIN INC. from 2019-02-01 until 2024-02-01
+	Intuit Inc. from 2024-02-01
 agaur123: agaur123!users.noreply.github.com
 	Independent until 2018-01-01
 	Intellect Design Arena from 2018-01-01 until 2018-06-01


### PR DESCRIPTION
affiliations outdated, possibly due to github user rename.