### PR TITLE
Fix a typo in a mapped company name

### DIFF
--- a/src/mapping.json
+++ b/src/mapping.json
@@ -457,7 +457,7 @@
   "BearingPoint": "BearingPoint GmbH",
   "Beautiful.ai": "Beautiful Slides Inc.",
   "Beechwoods": "Beechwoods Software Inc.",
-  "BeezLabs": "Beez Innovacion Labs Pvt. Ltd.",
+  "BeezLabs": "Beez Innovation Labs Pvt. Ltd.",
   "Beijing Equity Trading Center": "Beijing Equity Exchange Center Co Ltd.",
   "Bekk": "Bekk Consulting AS",
   "Belden": "Belden Inc.",


### PR DESCRIPTION
The company name Beez Innovation Labs Pvt. Ltd.  in `mapping.json` had a typo which is fixed in this PR.