### PR TITLE
Update developer affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -18288,7 +18288,7 @@ LeoHexspoor: LeoHexspoor!users.noreply.github.com
 LeoIannacone: info!leoiannacone.com, l3on!ubuntu.com
 	Canonical Ltd.
 LeonZh0u: leonzh0u!users.noreply.github.com, lzhou286!bloomberg.net
-	Bloomberg LP.
+	Bloomberg
 LeonardAukea: LeonardAukea!users.noreply.github.com, leonard.aukea!volvocars.com
 	Innoite until 2016-01-01
 	Independent from 2016-01-01 until 2017-03-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -8487,6 +8487,8 @@ jabcross: jabcross!users.noreply.github.com
 jabedude: j.abraham1776!gmail.com, jabedude!users.noreply.github.com
 	Independent until 2020-09-01
 	VMware Inc. from 2020-09-01
+jabellard: jabellard!users.noreply.github.com
+	Bloomberg
 jabelone: jabelone!users.noreply.github.com
 	Klearnet Solutions until 2014-09-01
 	Independent from 2014-09-01 until 2016-10-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -22934,7 +22934,7 @@ mszabo-wikia: 2721291+mszabo-wikia!users.noreply.github.com, mszabo-wikia!users.
 	Independent from 2016-08-01 until 2017-08-01
 	Fandom from 2017-08-01
 mszacillo: ma.szacillo!gmail.com, mszacillo!users.noreply.github.com
-	Workday Inc.
+	Bloomberg
 mszczodrak: mszczodrak!gmail.com, mszczodrak!users.noreply.github.com
 	Google LLC
 mszlgr: mszlgr!users.noreply.github.com


### PR DESCRIPTION
Update developer affiliations for @LeonZh0u, @jabellard, and @mszacillo.

For the company name, I took it from the [CNCF membership website](https://landscape.cncf.io/?group=members) where I guess the standard brand name.