### PR TITLE
Change Flant mapping to Flant JSC

### DIFF
--- a/src/mapping.json
+++ b/src/mapping.json
@@ -1322,7 +1322,7 @@
   "Fixate": "Fixate IO",
   "Fixstars": "Fixstars Corporation",
   "Fixt": "Fixtnow",
-  "Flant": "FLANT EUROPE OÜ",
+  "Flant": "Flant JCS",
   "Flexiana": "Flexiana LLC",
   "Flight Centre Travel Group": "Flight Centre Travel Group Limited",
   "Flipkart": "Flipkart Internet Private Limited",


### PR DESCRIPTION
One more thing I would like to change is the name of the Flant organization. The company with the name FLANT EUROPE OÜ was terminated (the info is public), and the better name now is the one you can find in the footer on the official Flant website (flant.com) - Flant JSC.