### PR TITLE
Add kpt maintainers from Ericsson

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -19973,6 +19973,8 @@ chzhyang: chzhyang!users.noreply.github.com, ge.yang!intel.com
 	Intel Corporation
 ci-robbot: ci-robbot!users.noreply.github.com
 	B
+ciaranjohnston: ciaranjohnston!users.noreply.github.com
+	Ericsson
 ciaranRoche: ciaranRoche!users.noreply.github.com, ciaranroche!hotmail.co.uk, croche!redhat.com
 	Independent until 2017-05-01
 	StitcherAds from 2017-05-01 until 2017-08-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -12782,6 +12782,8 @@ effy: t-koide!onlab.us
 efge: efge!users.noreply.github.com, fguillaume!nuxeo.com
 	Nuxeo until 2021-04-01
 	Apache from 2021-04-01
+efiacor: efimki!users.noreply.github.com
+	Ericsson
 efimki: efimki!users.noreply.github.com
 	Google LLC
 efirs: evgeniy.firsov!sandisk.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -12782,7 +12782,7 @@ effy: t-koide!onlab.us
 efge: efge!users.noreply.github.com, fguillaume!nuxeo.com
 	Nuxeo until 2021-04-01
 	Apache from 2021-04-01
-efiacor: efimki!users.noreply.github.com
+efiacor: efiacor!users.noreply.github.com
 	Ericsson
 efimki: efimki!users.noreply.github.com
 	Google LLC

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -9540,6 +9540,8 @@ liamawhite: liam!tetrate.io, liamawhite!gmail.com, liamawhite!users.noreply.gith
 liamchzh: liamchzh!users.noreply.github.com
 	International Business Machines Corporation until 2021-09-01
 	Points from 2021-09-01
+liamfallon: liamfallon!users.noreply.github.com
+	Ericsson
 liamgib: liamgib!users.noreply.github.com
 	Independent until 2018-10-01
 	Kmart from 2018-10-01 until 2019-05-01


### PR DESCRIPTION
Add the following developers from Ericsson working on  [kpt](https://github.com/kptdev) to the database
ciaranjohnston: Ciaran Johnston
efiacor: Fiachra Corcoran
liamfallon: Liam Fallon