### PR TITLE
feat: Add affiliation for titi0001

### DIFF
--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -21668,3 +21668,5 @@ zzzhy: candle_1667!163.com, zzzhy!users.noreply.github.com
 	Meituan
 zzztimbo: zzztimbo!users.noreply.github.com
 	Red Hat Inc.
+titi0001: titiura@gmail.com, 56649928+titi0001@users.noreply.github.com
+	Independent until 2021-06-01


### PR DESCRIPTION
This pull request adds/updates the affiliation for GitHub user titi0001.
It maps the email addresses (tiitura@gmail.com and 56649928+titi0001@users.noreply.github.com) to:
- Independent (until 2021-06-01, as per provided example in the file)

This ensures accurate tracking of contributions in DevStats.