### PR TITLE
fix(gitdm): prevent runtime errors by defaulting LogPatchSplitter dat…

### DIFF
--- a/src/logparser.py
+++ b/src/logparser.py
@@ -34,10 +34,11 @@ class LogPatchSplitter:
                 parse_patch(patch)
     """
 
-    def __init__(self, fd, date_from, date_to):
+    def __init__(self, fd, date_from=None, date_to=None):
         self.fd = fd
-        self.date_from = date_from
-        self.date_to = date_to
+        # Provide backward-compatible defaults when not supplied (as in older callers)
+        self.date_from = date_from or datetime.datetime(1970, 1, 1)
+        self.date_to = date_to or datetime.datetime(2069, 1, 1)
         self.buffer = None
         self.patch = []
 

--- a/src/reports.py
+++ b/src/reports.py
@@ -344,7 +344,7 @@ def ReportByReports (hlist):
         scount = len (h.reports)
         if scount > 0:
             ReportLine (h.full_name_with_aff(), scount, Pct(scount, totalreps))
-            report += scount
+            reported += scount
         count += 1
         if count >= ListCount:
             break


### PR DESCRIPTION
Title: fix: prevent runtime errors in core analysis pipeline

What was fixed or enhanced:
- Resolved a TypeError caused by a signature mismatch between `gitdm.py` and `logparser.LogPatchSplitter` by introducing default date range arguments.
- Fixed a NameError in `reports.ReportByReports` where `reported` was misspelled as `report`.

Why the change was necessary:
- `gitdm.py` instantiates `LogPatchSplitter(sys.stdin)` without date arguments; the previous constructor required them, causing immediate failure.
- The NameError in `ReportByReports` breaks report generation for “report credits”.

What exact changes were made:
- `src/logparser.py`: Updated `LogPatchSplitter.__init__` to accept optional `date_from`/`date_to` and provide wide default ranges.
- `src/reports.py`: Corrected variable name from `report` to `reported` inside `ReportByReports`.

How it improves the project:
- Restores backward compatibility with existing callers and prevents crashes in the main analysis flow.
- Ensures report generation for “report credits” completes successfully.

Verification steps:
1. Run a basic pipeline (using any git repo):
   ```
   git -C /path/to/repo log -p -M | python src/gitdm.py -b src/ -c gitdm.config-cncf -o out.txt
   ```
   - Expected: No TypeError from `LogPatchSplitter`; `out.txt` is generated.
2. Exercise `ReportByReports` by enabling reports in `gitdm.py` with standard inputs and ensure no NameError occurs.
3. Optional: Run regression tests from `src/`:
   ```
   python tests/gitdm-tests.py
   ```

Next steps (optional):
- Add CI to catch constructor regressions and run the Python tests.
- Plan phased Python 3 migration.

### Modified Files
- `src/logparser.py` ✅ push
- `src/reports.py` ✅ push