### PR TITLE
Fix(csv): correct headers and prevent extra blank lines on Windows

### DIFF
--- a/src/csvdump.py
+++ b/src/csvdump.py
@@ -59,17 +59,18 @@ def store_patch(patch):
 def save_csv (prefix='data'):
     # Dump the ChangeSets
     if len(ChangeSets) > 0:
-        fd = open('%s-changesets.csv' % prefix, 'w')
+        fd = open('%s-changesets.csv' % prefix, 'wb')
         writer = csv.writer (fd, quoting=csv.QUOTE_NONNUMERIC)
-        writer.writerow (['Commit', 'Date', 'Domain',
-                          'Email', 'Name', 'Affliation',
+        # Header aligned with emitted row order and corrected spelling
+        writer.writerow (['Commit', 'Date', 'Email',
+                          'Domain', 'Name', 'Affiliation',
                           'Added', 'Removed', 'Changed'])
         for commit in ChangeSets:
             writer.writerow(commit)
 
     # Dump the file types
     if len(FileTypes) > 0:
-        fd = open('%s-filetypes.csv' % prefix, 'w')
+        fd = open('%s-filetypes.csv' % prefix, 'wb')
         writer = csv.writer (fd, quoting=csv.QUOTE_NONNUMERIC)
 
         writer.writerow (['Commit', 'Type', 'Added', 'Removed'])
@@ -82,7 +83,7 @@ def OutputCSV (file):
     if file is None:
         return
     writer = csv.writer (file, quoting=csv.QUOTE_NONNUMERIC)
-    writer.writerow (['Name', 'Email', 'Affliation', 'Date',
+    writer.writerow (['Name', 'Email', 'Affiliation', 'Date',
                       'Added', 'Removed', 'Changed', 'Changesets'])
     for date, stat in PeriodCommitHash.items():
         # sanitise names " is common and \" sometimes too


### PR DESCRIPTION
This pull request makes improvements to the CSV output in `src/csvdump.py`, focusing on file writing compatibility and correcting header spelling. The most notable changes are the switch to binary mode for file writing and fixing a recurring typo in the CSV headers.

CSV file output improvements:

* Changed file opening mode from text (`'w'`) to binary (`'wb'`) when writing CSV files in the `save_csv` function to ensure compatibility with Python 2's `csv` module.
* Updated the order of columns and corrected the spelling of "Affiliation" (previously "Affliation") in the CSV header row in `save_csv` to match the emitted row order and improve accuracy.
* Corrected the spelling of "Affiliation" in the header row of the `OutputCSV` function.