### PR TITLE
Fix: restore legacy datelc file and add ./gitdm CLI wrapper

### DIFF
--- a/src/gitdm
+++ b/src/gitdm
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Thin wrapper to execute gitdm.py using a Python 2 compatible interpreter if available.
+# Falls back to `python` if neither pypy nor python2 are on PATH.
+# This restores the legacy `./gitdm` entrypoint expected by tests and docs.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if command -v pypy >/dev/null 2>&1; then
+  exec pypy "$DIR/gitdm.py" "$@"
+elif command -v python2 >/dev/null 2>&1; then
+  exec python2 "$DIR/gitdm.py" "$@"
+else
+  exec python "$DIR/gitdm.py" "$@"
+fi

--- a/src/gitdm.py
+++ b/src/gitdm.py
@@ -149,12 +149,21 @@ def PrintDateStats():
     dates = DateMap.keys ()
     dates.sort ()
     total = 0
-    datef = open ('datelc.csv', 'w')
-    datef.write('Date,Changed,Total Changed\n')
+    # Modern CSV output for external tooling
+    datef_csv = open('datelc.csv', 'w')
+    datef_csv.write('Date,Changed,Total Changed\n')
+    # Legacy fixed-width output expected by tests/back-compat
+    datef_legacy = open('datelc', 'w')
     for date in dates:
         total += DateMap[date]
-        datef.write ('%d/%02d/%02d,%d,%d\n' % (date.year, date.month, date.day,
+        # CSV
+        datef_csv.write('%d/%02d/%02d,%d,%d\n' % (date.year, date.month, date.day,
                                     DateMap[date], total))
+        # Legacy: date + two right-aligned integer columns width 7 and 8
+        datef_legacy.write('%d/%02d/%02d%7d%8d\n' % (date.year, date.month, date.day,
+                                    DateMap[date], total))
+    datef_csv.close()
+    datef_legacy.close()
 
 
 #


### PR DESCRIPTION
What was fixed or enhanced:
- Brought the gitdm date line count output back in line with the historical test expectations by writing the legacy `datelc` file (fixed-width format) in addition to the newer `datelc.csv` file.
- Reintroduced a `./gitdm` entrypoint as a thin wrapper around `gitdm.py` so tests and scripts that invoke `./gitdm` work without modification.

Why the change was necessary:
- The unit test `testDateLineCountOutputRegressionTest` expects a `datelc` file in a specific fixed-width format, but the current implementation only produced `datelc.csv`. This caused the test to fail.
- The test harness also invokes `./gitdm`, which did not exist in this fork (only `gitdm.py`), leading to execution failures.

What exact changes were made:
- Updated `src/gitdm.py` `PrintDateStats()` to write both:
  - `datelc.csv` (CSV, unchanged behavior) and
  - `datelc` (legacy fixed-width format matching `src/tests/expected-datelc`).
- Added `src/gitdm` bash wrapper that executes `gitdm.py` using `pypy`, `python2`, or `python` as available.

How it improves the project:
- Restores test compatibility and preserves CSV output for downstream tooling.
- Reduces friction for contributors and CI by ensuring `./gitdm` exists.

Verification steps:
1. From `src/`, ensure the wrapper is executable on POSIX systems: `chmod +x gitdm`.
2. Run tests: `python -m unittest -v tests/gitdm-tests.py` (or `python -m unittest discover -s tests -p "gitdm-tests.py"`).
3. Confirm both tests pass and `datelc` and `datelc.csv` are generated.

Next steps (optional):
- Consider normalizing documentation references to `enhance_json.sh` vs `enchance_json.sh` to remove typos and confusion.

Dependencies/config changes/tests:
- No new dependencies. Tests are unchanged but now pass with the restored outputs.

### Modified Files
- `src/gitdm.py` 
- `src/gitdm` 