### PR TITLE
fix: restore legacy datelc file and add ./gitdm CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Please follow the instructions from [SYNC.md](https://github.com/cncf/gitdm/blob
 # Running
 Use `*.sh` scripts to run analytics (`all*.sh` for full analysis and `rels*.sh` for per release stats)
 
+Convenience wrappers:
+- Unix shells: pipe `git log` into `./gitdm` instead of calling `src/cncfdm.py` directly; the wrapper auto-selects a Python 2/PyPy interpreter and points `-b` to `src/`.
+- PowerShell: use `./gitdm.ps1` similarly.
+
 This program assumes that gitdm resides in: `~/dev/cncf/gitdm/` and that kubernetes is in `~/dev/go/src/k8s.io/kubernetes/`
 
 Output files are placed in the `kubernetes` directory.

--- a/gitdm
+++ b/gitdm
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Lightweight CLI wrapper for cncfdm.py that picks a Python 2/PyPy interpreter
+# and points the engine at this repo's src/ directory by default.
+# Usage: git log ... | ./gitdm [cncfdm options]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$SCRIPT_DIR/src"
+ENGINE="$SCRIPT_DIR/src/cncfdm.py"
+
+# Allow override
+PY_BIN=${GITDM_PY:-}
+
+pick_python() {
+  if [[ -n "${PY_BIN}" ]]; then
+    echo "$PY_BIN"
+    return
+  fi
+  # Prefer explicit Python 2 binaries, then PyPy, then fall back to python if it is v2
+  for cand in python2 pypy pypy2; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      echo "$cand"; return
+    fi
+  done
+  if command -v python >/dev/null 2>&1; then
+    if python - <<'PY'
+import sys
+sys.exit(0 if sys.version_info[0] == 2 else 1)
+PY
+    then
+      echo python; return
+    fi
+  fi
+  echo ""  # not found
+}
+
+PY_CMD=$(pick_python || true)
+if [[ -z "$PY_CMD" ]]; then
+  echo "error: gitdm requires Python 2 or PyPy. Install python2/pypy or set GITDM_PY to a suitable interpreter." >&2
+  exit 1
+fi
+
+exec "$PY_CMD" "$ENGINE" -b "$BASE_DIR/" "$@"

--- a/gitdm.ps1
+++ b/gitdm.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env pwsh
+param([Parameter(ValueFromRemainingArguments=$true)] [string[]]$Args)
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BaseDir = Join-Path $ScriptDir 'src'
+$Engine  = Join-Path $BaseDir 'cncfdm.py'
+
+function Pick-Python {
+  if ($env:GITDM_PY) { return $env:GITDM_PY }
+  foreach ($cand in @('py -2','python2','pypy','pypy2')) {
+    try {
+      if ($cand -eq 'py -2') {
+        & py -2 - <<'PY'
+import sys
+print(2 if sys.version_info[0]==2 else 3)
+PY
+        if ($LASTEXITCODE -eq 0) { return 'py -2' }
+      } else {
+        if (Get-Command ($cand.Split(' ')[0]) -ErrorAction SilentlyContinue) { return $cand }
+      }
+    } catch { }
+  }
+  if (Get-Command python -ErrorAction SilentlyContinue) {
+    $ver = & python - <<'PY'
+import sys
+print(sys.version_info[0])
+PY
+    if ($ver -eq 2) { return 'python' }
+  }
+  return $null
+}
+
+$py = Pick-Python
+if (-not $py) {
+  Write-Error 'gitdm requires Python 2 or PyPy. Install python2/pypy or set GITDM_PY.'
+  exit 1
+}
+
+# Pass through stdin/stdout; add -b to point at src/
+& $py $Engine -b "$BaseDir/" @Args
+exit $LASTEXITCODE

--- a/src/ConfigFile.py
+++ b/src/ConfigFile.py
@@ -169,7 +169,7 @@ def ReadFileType (filename):
         m = regex_file_type.match (line)
         if not m or len (m.groups ()) != 2:
             ConfigFile.croak ('Funky file type line "%s"' % (line))
-        if not patterns.has_key (m.group (1)):
+        if m.group (1) not in patterns:
             patterns[m.group (1)] = []
         if m.group (1) not in order:
             print '%s not found, appended to the last order' % m.group (1)
@@ -187,9 +187,9 @@ def ReadFileType (filename):
 
 def ConfigFile (name, confdir):
     try:
-        file = open (confdir + name, 'r')
+        file = open (os.path.join(confdir, name), 'r')
     except IOError:
-        croak ('Unable to open config file %s' % (confdir + name))
+        croak ('Unable to open config file %s' % (os.path.join(confdir, name)))
     line = ReadConfigLine (file)
     while line:
         sline = line.split (None, 2)

--- a/src/cncfdm.py
+++ b/src/cncfdm.py
@@ -348,7 +348,7 @@ class patch:
         self.reports.append (reporter)
 
     def addfiletype (self, filetype, added, removed):
-        if self.filetypes.has_key (filetype):
+        if filetype in self.filetypes:
             self.filetypes[filetype][self.ADDED] += added
             self.filetypes[filetype][self.REMOVED] += removed
         else:

--- a/src/database.py
+++ b/src/database.py
@@ -263,7 +263,7 @@ class Employer:
 Employers = { }
 
 def GetEmployer (name):
-    if CompanyMap.has_key (name):
+    if name in CompanyMap:
         name = CompanyMap[name]
     try:
         return Employers[name]
@@ -300,10 +300,11 @@ class VirtualEmployer (Employer):
             real.removed += int (self.removed*fraction)
             real.changed += int (self.changed*fraction)
             real.count += int (self.count*fraction)
-        self.__init__ (name) # Reset counts just in case
+        # Reset counts while preserving the virtual employer's original name
+        self.__init__ (self.name) # Reset counts just in case
 
     def store (self):
-        if Employers.has_key (self.name):
+        if self.name in Employers:
             print Employers[self.name]
             sys.stderr.write ('WARNING: Virtual empl %s overwrites another\n'
                               % (self.name))
@@ -323,7 +324,7 @@ class FileType:
         order = order or self.order
 
         for file_type in order:
-            if patterns.has_key (file_type):
+            if file_type in patterns:
                 for patt in patterns[file_type]:
                     if patt.search (filename):
                         return file_type
@@ -349,14 +350,14 @@ def MixVirtuals ():
 EmailAliases = { }
 
 def AddEmailAlias (variant, canonical):
-    if EmailAliases.has_key (variant):
+    if variant in EmailAliases:
         sys.stderr.write ('Duplicate email alias for %s\n' % (email_encode(variant)))
     EmailAliases[variant] = canonical
 
 CompanyMap = { }
 
 def AddCompanyMap(nameFrom, nameTo):
-    if CompanyMap.has_key (nameFrom):
+    if nameFrom in CompanyMap:
         sys.stderr.write ('Duplicate company map for %s\n' % (nameFrom))
     CompanyMap[nameFrom] = nameTo
 

--- a/src/logparser.py
+++ b/src/logparser.py
@@ -53,6 +53,10 @@ class LogPatchSplitter:
             raise StopIteration
         return patch
 
+    # Py3 compatibility when/if the project is ported
+    def __next__(self):
+        return self.next()
+
     def getDate(self, line):
         # ['Date:', '', '', 'Thu', 'May', '11', '09:15:21', '2017', '+0200\n']
         arr = line.split(' ')

--- a/src/rels.sh
+++ b/src/rels.sh
@@ -1,14 +1,19 @@
+#!/bin/sh
+# Batch per-release runs writing outputs under $GITDM_HOME/kubernetes/*
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+out() { mv output_* "$GITDM_HOME/kubernetes/$1"; }
+
 ./run_for_rels.sh v1.0.0 v1.1.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.0.0-v1.1.0
+out v1.0.0-v1.1.0
 ./run_for_rels.sh v1.1.0 v1.2.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.1.0-v1.2.0
+out v1.1.0-v1.2.0
 ./run_for_rels.sh v1.2.0 v1.3.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.2.0-v1.3.0
+out v1.2.0-v1.3.0
 ./run_for_rels.sh v1.3.0 v1.4.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.3.0-v1.4.0
+out v1.3.0-v1.4.0
 ./run_for_rels.sh v1.4.0 v1.5.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.4.0-v1.5.0
+out v1.4.0-v1.5.0
 ./run_for_rels.sh v1.5.0 v1.6.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.5.0-v1.6.0
+out v1.5.0-v1.6.0
 ./run_for_rels.sh v1.6.0 v1.7.0
-mv output_* ~/dev/cncf/gitdm/kubernetes/v1.6.0-v1.7.0
+out v1.6.0-v1.7.0

--- a/src/rels_no_map.sh
+++ b/src/rels_no_map.sh
@@ -1,14 +1,18 @@
+#!/bin/sh
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+out() { mv output_no_map_* "$GITDM_HOME/kubernetes/$1"; }
+
 ./run_for_rels_no_map.sh v1.0.0 v1.1.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.0.0-v1.1.0
+out v1.0.0-v1.1.0
 ./run_for_rels_no_map.sh v1.1.0 v1.2.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.1.0-v1.2.0
+out v1.1.0-v1.2.0
 ./run_for_rels_no_map.sh v1.2.0 v1.3.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.2.0-v1.3.0
+out v1.2.0-v1.3.0
 ./run_for_rels_no_map.sh v1.3.0 v1.4.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.3.0-v1.4.0
+out v1.3.0-v1.4.0
 ./run_for_rels_no_map.sh v1.4.0 v1.5.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.4.0-v1.5.0
+out v1.4.0-v1.5.0
 ./run_for_rels_no_map.sh v1.5.0 v1.6.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.5.0-v1.6.0
+out v1.5.0-v1.6.0
 ./run_for_rels_no_map.sh v1.6.0 v1.7.0
-mv output_no_map_* ~/dev/cncf/gitdm/kubernetes/v1.6.0-v1.7.0
+out v1.6.0-v1.7.0

--- a/src/rels_strict.sh
+++ b/src/rels_strict.sh
@@ -1,14 +1,18 @@
+#!/bin/sh
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+out() { mv output_strict_* "$GITDM_HOME/kubernetes/$1"; }
+
 ./run_for_rels_strict.sh v1.0.0 v1.1.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.0.0-v1.1.0
+out v1.0.0-v1.1.0
 ./run_for_rels_strict.sh v1.1.0 v1.2.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.1.0-v1.2.0
+out v1.1.0-v1.2.0
 ./run_for_rels_strict.sh v1.2.0 v1.3.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.2.0-v1.3.0
+out v1.2.0-v1.3.0
 ./run_for_rels_strict.sh v1.3.0 v1.4.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.3.0-v1.4.0
+out v1.3.0-v1.4.0
 ./run_for_rels_strict.sh v1.4.0 v1.5.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.4.0-v1.5.0
+out v1.4.0-v1.5.0
 ./run_for_rels_strict.sh v1.5.0 v1.6.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.5.0-v1.6.0
+out v1.5.0-v1.6.0
 ./run_for_rels_strict.sh v1.6.0 v1.7.0
-mv output_strict_* ~/dev/cncf/gitdm/kubernetes/v1.6.0-v1.7.0
+out v1.6.0-v1.7.0

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,14 +1,24 @@
 #!/bin/sh
+# Portable runner for all-time analysis of the main repo.
+# Honors env vars:
+#   GITDM_HOME - path to this repo (defaults to parent of this script)
+#   K8S_REPO   - path to kubernetes repo (defaults to $HOME/dev/go/src/k8s.io/kubernetes)
+
 PWD=`pwd`
 FNP=$PWD/first_run_patch
 FNN=$PWD/first_run_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+# Resolve repo roots
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # git log --all -p -M | cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/gitdm/ > first_run.txt
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 cd $PWD

--- a/src/run_for_rels.sh
+++ b/src/run_for_rels.sh
@@ -1,18 +1,26 @@
 #!/bin/sh
+# Portable per-release runner between two git tags.
+# Honors env vars:
+#   GITDM_HOME - path to this repo (defaults to parent of this script)
+#   K8S_REPO   - path to kubernetes repo (defaults to $HOME/dev/go/src/k8s.io/kubernetes)
+
 if [ $# -lt 2 ]; then
   echo "$0 tag1 tag2"
-  echo "Use "git tag -l" to see available tags"
+  echo "Use \"git tag -l\" to see available tags"
   exit 1
 fi
 PWD=`pwd`
 FNP=$PWD/output_patch
 FNN=$PWD/output_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 ls -l $FNP* $FNN*


### PR DESCRIPTION
This PR restores the legacy `datelc` output expected by existing automation and introduces a first-class `./gitdm` CLI (plus Windows `./gitdm.ps1`) that chooses a Python 2/PyPy interpreter and points the engine at `src/` automatically. In the process, it removes hard-coded paths, adds shebangs, and fixes a bug in `VirtualEmployer.applysplits`. Minor Python modernizations improve maintainability without changing behavior.


## Code changes summary

- Wrapper CLIs: `gitdm`, `gitdm.ps1`
- Portability: `src/run.sh`, `src/run_for_rels.sh`, `src/rels.sh`, `src/rels_no_map.sh`, `src/rels_strict.sh`
- Engine fixes: `src/database.py` (applysplits), `src/ConfigFile.py` (path join), `src/cncfdm.py`/`src/database.py` (dict membership), `src/logparser.py` (iterator)
- Docs: `README.md` usage note

## Testing instructions

1. Build Go helpers (optional): `cd src && make check && make all`
2. Run all‑time analysis (example):
   - Linux/macOS: `git -C /path/to/repo log --no-merges --numstat -M | ./gitdm -n -r "^vendor/|/vendor/|^Godeps/" -R -b src/ -t -z -d -D -U -u -h out.html -o out.txt -x out.csv`
   - Windows (PowerShell): `git -C C:\path\to\repo log --no-merges --numstat -M | ./gitdm.ps1 -n -r "^vendor/|/vendor/|^Godeps/" -R -t -z -d -D -U -u -h out.html -o out.txt -x out.csv`
3. Per‑release example: `cd src && ./run_for_rels.sh v1.5.0 v1.6.0` (set `K8S_REPO` if needed)
4. Verify legacy `datelc` file is generated and downstream tooling consumes it.

Signed-off-by: Shubham Shukla <shubhushukla586@gmail.com>
