### PR TITLE
Restore legacy datelc, fix ConfigFile error path, and sanitize CSV author names

### DIFF
--- a/src/ConfigFile.py
+++ b/src/ConfigFile.py
@@ -168,7 +168,7 @@ def ReadFileType (filename):
 
         m = regex_file_type.match (line)
         if not m or len (m.groups ()) != 2:
-            ConfigFile.croak ('Funky file type line "%s"' % (line))
+            croak ('Funky file type line "%s"' % (line))
         if m.group (1) not in patterns:
             patterns[m.group (1)] = []
         if m.group (1) not in order:

--- a/src/cncfdm.py
+++ b/src/cncfdm.py
@@ -311,12 +311,21 @@ def PrintDateStats():
     dates = DateMap.keys ()
     dates.sort ()
     total = 0
-    datef = open ('datelc.csv', 'w')
-    datef.write('Date,Changed,Total Changed\n')
+    # Modern CSV output for external tooling
+    datef_csv = open('datelc.csv', 'w')
+    datef_csv.write('Date,Changed,Total Changed\n')
+    # Legacy fixed-width output expected by tests/back-compat
+    datef_legacy = open('datelc', 'w')
     for date in dates:
         total += DateMap[date]
-        datef.write ('%d/%02d/%02d,%d,%d\n' % (date.year, date.month, date.day,
+        # CSV
+        datef_csv.write('%d/%02d/%02d,%d,%d\n' % (date.year, date.month, date.day,
                                     DateMap[date], total))
+        # Legacy: date + two right-aligned integer columns width 7 and 8
+        datef_legacy.write('%d/%02d/%02d%7d%8d\n' % (date.year, date.month, date.day,
+                                    DateMap[date], total))
+    datef_csv.close()
+    datef_legacy.close()
 
 
 #
@@ -571,12 +580,12 @@ def grabpatch(logpatch):
             # Get the statistics (lines added/removes) using numstats
             # and without requiring a diff (--numstat instead -p)
             (filename, filetype, added, removed) = parse_numstat (Line, FileFilter)
-	    if filename:
-	        pa.added += added
-		pa.removed += removed
-		pa.addfiletype (filetype, added, removed)
+            if filename:
+                pa.added += added
+                pa.removed += removed
+                pa.addfiletype (filetype, added, removed)
                 if FileStats:
-		    pa.addfile (filename, added, removed)
+                    pa.addfile (filename, added, removed)
 
     if '@' in pa.author.name:
         GripeAboutAuthorName (pa.author.name)

--- a/src/csvdump.py
+++ b/src/csvdump.py
@@ -43,14 +43,15 @@ def store_patch(patch):
     if not patch.merge:
         employer = patch.author.emailemployer(patch.email, patch.date)
         employer = employer.name.replace('"', '.').replace ('\\', '.')
-        author = patch.author.name.replace ('"', '.').replace ('\\', '.')
-        author = email_encode(patch.author.name.replace ("'", '.'))
+        # Sanitize and encode author name consistently (quotes, slashes, apostrophes, and emails)
+        _author = patch.author.name.replace('"', '.').replace('\\', '.')
+        _author = email_encode(_author.replace("'", '.'))
         try:
             domain = patch.email.split('@')[1]
         except:
             domain = patch.email
         ChangeSets.append([patch.commit, str(patch.date),
-                           email_encode(patch.email), domain, author, employer,
+                           email_encode(patch.email), domain, _author, employer,
                            patch.added, patch.removed, max(patch.added, patch.removed)])
         for (filetype, (added, removed)) in patch.filetypes.iteritems():
             FileTypes.append([patch.commit, filetype, added, removed])
@@ -67,6 +68,7 @@ def save_csv (prefix='data'):
                           'Added', 'Removed', 'Changed'])
         for commit in ChangeSets:
             writer.writerow(commit)
+        fd.close()
 
     # Dump the file types
     if len(FileTypes) > 0:
@@ -76,6 +78,7 @@ def save_csv (prefix='data'):
         writer.writerow (['Commit', 'Type', 'Added', 'Removed'])
         for commit in FileTypes:
             writer.writerow(commit)
+        fd.close()
 
 
 

--- a/src/gitdm.py
+++ b/src/gitdm.py
@@ -323,11 +323,11 @@ def grabpatch(logpatch):
         else:
             # Get the statistics (lines added/removes) using numstats
             # and without requiring a diff (--numstat instead -p)
-			(filename, filetype, added, removed) = parse_numstat (Line, FileFilter)
-			if filename:
-			    p.added += added
-			    p.removed += removed
-			    p.addfiletype (filetype, added, removed)
+            (filename, filetype, added, removed) = parse_numstat (Line, FileFilter)
+            if filename:
+                p.added += added
+                p.removed += removed
+                p.addfiletype (filetype, added, removed)
 
     if '@' in p.author.name:
         GripeAboutAuthorName (p.author.name)


### PR DESCRIPTION
This PR makes small, safe corrections that improve stability and correctness without changing behavior or adding features:

1) Restore legacy `datelc` file (cncfdm.py)
- Problem: `src/tests/gitdm-tests.py` expects a `datelc` file for the `-D` path, but cncfdm only wrote `datelc.csv`.
- Fix: Write both `datelc.csv` (modern, with header) and legacy `datelc` (fixed‑width, no header) like the historical `gitdm.py` did.
- Impact: Tests and existing downstream scripts relying on `datelc` work again; no change to CSV output.

2) Correct error path in `ReadFileType()` (ConfigFile.py)
- Problem: Code called `ConfigFile.croak`, which referenced a function attribute that doesn’t exist; on malformed lines this would raise the wrong exception.
- Fix: Call module‑level `croak()` directly.
- Impact: Proper, user‑friendly error handling on bad file‑type config lines.

3) CSV output hygiene (csvdump.py)
- Problem: Author name was sanitized, then immediately overwritten, dropping quote/backslash sanitization; CSV files were left unclosed.
- Fix: Sanitize once (quotes, backslashes, apostrophes) then `email_encode`; close CSV files after writing.
- Impact: More robust CSVs on Windows and fewer chances of malformed fields; semantics unchanged.

4) Indentation normalization (cncfdm.py, gitdm.py)
- Problem: Mixed tabs/spaces in a small block under `--numstat` handling.
- Fix: Convert those lines to spaces; no logic changes.
- Impact: Avoids potential TabError/formatting issues; behavior identical.

## Verification
- Changes are isolated and additive.
- The `-D` flow now emits both `datelc.csv` and `datelc` (legacy), matching expectations in `src/tests/gitdm-tests.py`.
- No core counting logic, parsing, or report math was changed.
- CSV headers and rows are unchanged except for safer author-name sanitization (previously intended but accidentally bypassed).

## Risk assessment
- Very low. The only observable output change is the presence of the legacy `datelc` file (additive) and correctly sanitized author names in ChangeSets CSVs.

## How to test
- Run the regression tests from repo root:
  - `python src/tests/gitdm-tests.py`
- Or quick smoke‐test for `-D` path:
  - `git --git-dir src/tests/testrepo log -p -M | ./gitdm -D`
  - Verify both `datelc` and `datelc.csv` are created and `datelc` matches `src/tests/expected-datelc`.
xpected by tests. No breaking changes.