### PR TITLE
fix(configfile): skip comment lines correctly

### DIFF
--- a/gitdm.ps1
+++ b/gitdm.ps1
@@ -10,10 +10,7 @@ function Pick-Python {
   foreach ($cand in @('py -2','python2','pypy','pypy2')) {
     try {
       if ($cand -eq 'py -2') {
-        & py -2 - <<'PY'
-import sys
-print(2 if sys.version_info[0]==2 else 3)
-PY
+        & py -2 -c "import sys; assert sys.version_info[0]==2" 1>$null 2>$null
         if ($LASTEXITCODE -eq 0) { return 'py -2' }
       } else {
         if (Get-Command ($cand.Split(' ')[0]) -ErrorAction SilentlyContinue) { return $cand }
@@ -21,10 +18,7 @@ PY
     } catch { }
   }
   if (Get-Command python -ErrorAction SilentlyContinue) {
-    $ver = & python - <<'PY'
-import sys
-print(sys.version_info[0])
-PY
+    $ver = & python -c "import sys; print(sys.version_info[0])"
     if ($ver -eq 2) { return 'python' }
   }
   return $null

--- a/src/ConfigFile.py
+++ b/src/ConfigFile.py
@@ -22,8 +22,9 @@ def ReadConfigLine (file):
     line = file.readline ()
     if not line:
         return None
+    # Skip comment lines entirely and continue reading
     if line.startswith('#'):
-        return ''
+        return ReadConfigLine (file)
     line = line.strip () # and extra white space
     line = email_decode(line)
     if len (line) == 0: # we got rid of everything
@@ -152,7 +153,7 @@ def ReadFileType (filename):
         file = open (filename, 'r')
     except IOError:
         croak ('Unable to open file type mapping file %s' % (filename))
-    patterns = {}
+    ft_patterns = {}
     order = []
     regex_order = re.compile ('^order\s+(.*)$')
     regex_file_type = re.compile ('^filetype\s+(\S+)\s+(.+)$')
@@ -170,17 +171,17 @@ def ReadFileType (filename):
         if not m or len (m.groups ()) != 2:
             croak ('Funky file type line "%s"' % (line))
 
-        if m.group (1) not in patterns:
-            patterns[m.group (1)] = []
+        if m.group (1) not in ft_patterns:
+            ft_patterns[m.group (1)] = []
         if m.group (1) not in order:
             print '%s not found, appended to the last order' % m.group (1)
             order.append (m.group (1))
 
-        patterns[m.group (1)].append (re.compile (m.group (2), re.IGNORECASE))
+        ft_patterns[m.group (1)].append (re.compile (m.group (2), re.IGNORECASE))
 
         line = ReadConfigLine (file)
     file.close ()
-    return patterns, order
+    return ft_patterns, order
 
 #
 # Read an overall config file.

--- a/src/reports.py
+++ b/src/reports.py
@@ -473,9 +473,9 @@ def EmplReviews (elist, totalreviews):
 # Who are the unknown hackers?
 #
 def IsUnknown(h):
-    # LG: need to take a look
+    # LG: treat developers as unknown if employer is unmapped or explicitly not found
     empl = h.employer[0][0][1].name
-    return h.email[0] == empl or empl == '(Unknown)' or empl == 'NotFound'
+    return h.email[0] == empl or empl in ('(Unknown)', '(Not Found)')
 
 def IsSelf(h):
     empl = h.employer[0][0][1].name
@@ -535,7 +535,6 @@ def ReportSelfs(hlist, cscount):
 
 def ReportByFileType (hacker_list):
     total = {}
-    total_by_hacker = {}
 
     BeginReport ('Developer contributions by type')
     for h in hacker_list:
@@ -556,10 +555,10 @@ def ReportByFileType (hacker_list):
                 else:
                     total[filetype] = [added, removed, []]
 
-        # Print a summary by hacker
-        print email_encode(h.full_name_with_aff())
+        # Print a summary by hacker using the configured output stream
+        Write(email_encode(h.full_name_with_aff()) + '\n')
         for filetype, counters in by_hacker.iteritems():
-            print '\t', filetype, counters
+            Write('\t%s %s\n' % (filetype, counters))
             h_added = by_hacker[filetype][patch.ADDED]
             h_removed = by_hacker[filetype][patch.REMOVED]
             total[filetype][2].append ([h.full_name_with_aff(), h_added, h_removed])
@@ -567,11 +566,11 @@ def ReportByFileType (hacker_list):
     # Print the global summary
     BeginReport ('Contributions by type and developers')
     for filetype, (added, removed, hackers) in total.iteritems():
-        print filetype, added, removed
+        Write('%s %d %d\n' % (filetype, added, removed))
         for h, h_added, h_removed in hackers:
-            print email_encode('\t%s: [%d, %d]' % (h, h_added, h_removed))
+            Write(email_encode('\t%s: [%d, %d]' % (h, h_added, h_removed)) + '\n')
 
     # Print the very global summary
     BeginReport ('General contributions by type')
     for filetype, (added, removed, hackers) in total.iteritems():
-        print filetype, added, removed
+        Write('%s %d %d\n' % (filetype, added, removed))


### PR DESCRIPTION
### Summary
This PR fixes the config file parser to correctly skip comment lines and improves report output consistency.

### Changes

#### 1. `src/ConfigFile.py`
- **Fix comment handling**: Changed `ReadConfigLine()` to recursively skip comment lines instead of returning an empty string. This ensures commented lines are fully ignored rather than being processed as blank lines.
- **Rename variable**: Renamed `patterns` to `ft_patterns` in `ReadFileType()` for clarity.

#### 2. `src/reports.py`
- **Fix unknown employer check**: Updated `IsUnknown()` to check for `'(Not Found)'` instead of `'NotFound'` to match actual data format.
- **Use Write() instead of print**: Replaced raw `print` statements with `Write()` calls in `ReportByFileType()` for consistent output handling.
- **Remove unused variable**: Removed unused `total_by_hacker` dictionary.

#### 3. `gitdm.ps1`
- **Simplify Python detection**: Replaced here-string Python version checks with inline `-c` commands for cleaner PowerShell syntax.

### Files Changed
| File | Changes |
|------|--------|
| `src/ConfigFile.py` | +7 / -6 |
| `src/reports.py` | +8 / -9 |
| `gitdm.ps1` | +2 / -8 |

### Impact

- **Config parsing reliability**: Comment lines in config files (e.g., `gitdm.config`, `filetypes.cfg`) will now be properly skipped without creating empty-line side effects. Previously, commented lines returned empty strings which could cause unexpected behavior in downstream parsing.

- **Report accuracy**: The `IsUnknown()` fix ensures developers with unmapped employers are correctly identified as "unknown" — reports will now accurately reflect contributor affiliation status.

- **Output consistency**: Using `Write()` instead of `print` in `ReportByFileType()` ensures all report output goes through the configured output stream, making it easier to redirect or capture programmatically.

- **Script maintainability**: Simplified Python detection in `gitdm.ps1` reduces code complexity and removes heredoc syntax that can be problematic in certain PowerShell environments.


