### PR TITLE
fix: prevent -m mode crash on single-label domains

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -396,7 +396,11 @@ def AddEmailEmployerMapping (email, employer, end = nextyear, domain = False):
 # LG: Artificial Domains from Hacker's email domain names
 ArtificialDomains = {}
 def GetHackerDomain(dom, email):
-    new_dom = ''.join(map(lambda x: x.lower().capitalize(), dom.split('.')[:-1]))
+    parts = dom.split('.')
+    # If the domain has no dot (e.g. "localhost"), keep the whole value so we
+    # generate a meaningful label instead of just " *".
+    name_parts = parts if len(parts) == 1 else parts[:-1]
+    new_dom = ''.join(map(lambda x: x.lower().capitalize(), name_parts))
     new_dom += ' *'
     key = (new_dom, dom)
     if key not in ArtificialDomains:
@@ -420,7 +424,10 @@ def MapToEmployer (email, unknown = 0):
     if len (namedom) < 2:
         print 'Oops...funky email %s' % email_encode(email)
         return [(nextyear, GetEmployer ('Funky'), False)]
-    s = namedom[1].split ('.')
+    domain = namedom[1]
+    s = domain.split ('.')
+    # Keep a usable default for unknown==1 even when the domain has no dots.
+    addr = domain
     for dots in range (len (s) - 2, -1, -1):
         addr = '.'.join (s[dots:])
         try:

--- a/src/logparser.py
+++ b/src/logparser.py
@@ -63,7 +63,7 @@ class LogPatchSplitter:
         arr2 = []
         for i in range(len(arr) - 1):
             s = arr[i]
-            if s != '' and s != 'Date:':
+            if s and s not in ('Date:', 'CommitDate:'):
                 arr2.append(s)
         datestr = ' '.join(arr2)
         date = datetime.datetime.strptime(datestr, '%a %b %d %H:%M:%S %Y')


### PR DESCRIPTION
## Summary
This PR fixes a crash when mapping unknown affiliations to email domains (`-m`) for emails whose domain has no dot (e.g. `user@localhost`). It also hardens date parsing in `logparser.py` to accept `CommitDate:` lines.

## Background / Reasoning
- `database.MapToEmployer()` iterates domain suffixes to find domain mappings, but for single-label domains the suffix loop never runs, leaving `addr` undefined. When `unknown == 1`, this leads to an exception instead of producing a domain-based fallback.
- `logparser.getDate()` only skipped the `Date:` token; if the input contains `CommitDate:` (possible with `git log --pretty=fuller`), date parsing can fail.

## Changes
- `src/database.py`
  - Ensure `addr` is always defined before domain suffix iteration.
  - Make `GetHackerDomain()` treat single-label domains as a real label (e.g. `Localhost *`) instead of producing `" *"`.
- `src/logparser.py`
  - Ignore the `CommitDate:` token when extracting the date string.

## Impact
- No behavior change for normal dot-separated domains (e.g. `gmail.com`, `example.co.uk`).
- Prevents a hard crash in `-m` mode for single-label domains.
- Improves robustness when `CommitDate:` lines are present in the git log input.

## Compatibility / Non-overlap
- Based on current `master` (includes recent merges up through `e5595aa1`).
- Changes are isolated and do not revert or duplicate previously merged fixes.

## Verification
- Change is intentionally minimal and guarded:
  - Existing behavior is unchanged for common inputs.
  - New behavior only applies to previously-crashing edge cases.
- No new features added.