### PR TITLE
Fix runner scripts and PowerShell wrapper (correct cncfdm path + stdin passthrough)

### DIFF
--- a/src/all_no_map.sh
+++ b/src/all_no_map.sh
@@ -1,2 +1,3 @@
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
 ./run_no_map.sh
-mv run_no_map_* ~/dev/cncf/gitdm/kubernetes/all_time/
+mv run_no_map_* "$GITDM_HOME/kubernetes/all_time/"

--- a/src/all_with_map.sh
+++ b/src/all_with_map.sh
@@ -1,2 +1,3 @@
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
 ./run_with_map.sh
-mv run_with_map_* ~/dev/cncf/gitdm/kubernetes/all_time/
+mv run_with_map_* "$GITDM_HOME/kubernetes/all_time/"

--- a/src/anyrepo.sh
+++ b/src/anyrepo.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 PWD=`pwd`
 FN=$PWD/repos/$2
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
 cd "$1"
 echo "Processing repo $1 $2"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
-git log --all --numstat -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $FN.html -o $FN.txt -x $FN.csv > $FN.out
+git log --all --numstat -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $FN.html -o $FN.txt -x $FN.csv > $FN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit

--- a/src/anyreporange.sh
+++ b/src/anyreporange.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 PWD=`pwd`
 FN=$PWD/repo_$2_$3
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
 cd "$1"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
-git log --all --numstat -M --since "$2" --until "$3" | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -f "$2" -e "$3" -h $FN.html -o $FN.txt -x $FN.csv > $FN.out
+git log --all --numstat -M --since "$2" --until "$3" | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -f "$2" -e "$3" -h $FN.html -o $FN.txt -x $FN.csv > $FN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit

--- a/src/commits_in_ranges.sh
+++ b/src/commits_in_ranges.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+if [ $# -lt 4 ]; then
+  echo "Usage: $0 prefix git.log dt_from dt_to"
+  exit 1
+fi
 echo "Args git.log dt_from dt_to"
 WD=`pwd`
 PREFIX=$1
@@ -6,6 +10,8 @@ FN=$2
 F=$WD/other_repos/$1_range_unknown_$3_$4
 F2=$WD/other_repos/$1_range_no_map_$3_$4
 F3=$WD/other_repos/$1_range_with_map_$3_$4
-cat $FN | ~/dev/cncf/gitdm/cncfdm.py -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $F.html -o $F.txt -x $F.csv > $F.out
-#cat $FN | ~/dev/cncf/gitdm/cncfdm.py -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $F2.html -o $F2.txt -x $F2.csv > $F2.out
-#cat $FN | ~/dev/cncf/gitdm/cncfdm.py -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $F3.html -o $F3.txt -x $F3.csv > $F3.out
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cat $FN | "$CNCFDM" -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $F.html -o $F.txt -x $F.csv > $F.out
+#cat $FN | "$CNCFDM" -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -h $F2.html -o $F2.txt -x $F2.csv > $F2.out
+#cat $FN | "$CNCFDM" -f "$3" -e "$4" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $F3.html -o $F3.txt -x $F3.csv > $F3.out

--- a/src/multirepo.sh
+++ b/src/multirepo.sh
@@ -4,6 +4,8 @@ FN=$WD/git.log
 F=$WD/repos/combined
 F2=$WD/repos/combined_no_map
 F3=$WD/repos/combined_with_map
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
 > $FN
 for var in "$@"
 do
@@ -18,9 +20,9 @@ do
 done
 PWD=$WD
 cd $PWD
-cat $FN | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $F.html -o $F.txt -x $F.csv > $F.out
-cat $FN | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $F2.html -o $F2.txt -x $F2.csv > $F2.out
-cat $FN | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $F3.html -o $F3.txt -x $F3.csv > $F3.out
+cat $FN | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $F.html -o $F.txt -x $F.csv > $F.out
+cat $FN | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -h $F2.html -o $F2.txt -x $F2.csv > $F2.out
+cat $FN | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $F3.html -o $F3.txt -x $F3.csv > $F3.out
 ./commits_in_default_ranges.sh all_kubernetes $FN
 #rm -f $FN
 #xz -9 $FN

--- a/src/rerun_data.sh
+++ b/src/rerun_data.sh
@@ -4,7 +4,7 @@ echo "Update PULL_DATE after this, and update datasheet dates and report dates t
 echo "Also update last_processed.txt with last processed unknown/not found affliation from repos/combined.txt"
 rm -f ./other_repos/*
 echo "All with map to (Unknown)"
-./all.sh
+./run_all.sh
 echo "All without mapping"
 ./all_no_map.sh
 echo "All with map to Domain *"

--- a/src/run_all.sh
+++ b/src/run_all.sh
@@ -1,2 +1,3 @@
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
 ./run.sh
-mv first_run_* ~/dev/cncf/gitdm/kubernetes/all_time/
+mv first_run_* "$GITDM_HOME/kubernetes/all_time/"

--- a/src/run_for_rels_no_map.sh
+++ b/src/run_for_rels_no_map.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
 if [ $# -lt 2 ]; then
   echo "$0 tag1 tag2"
-  echo "Use "git tag -l" to see available tags"
+  echo 'Use "git tag -l" to see available tags'
   exit 1
 fi
 PWD=`pwd`
 FNP=$PWD/output_no_map_patch
 FNN=$PWD/output_no_map_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 ls -l $FNP* $FNN*

--- a/src/run_for_rels_strict.sh
+++ b/src/run_for_rels_strict.sh
@@ -1,18 +1,21 @@
 #!/bin/sh
 if [ $# -lt 2 ]; then
   echo "$0 tag1 tag2"
-  echo "Use "git tag -l" to see available tags"
+  echo 'Use "git tag -l" to see available tags'
   exit 1
 fi
 PWD=`pwd`
 FNP=$PWD/output_strict_patch
 FNN=$PWD/output_strict_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M $1..$2 | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -u -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M $1..$2 | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -u -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 ls -l $FNP* $FNN*

--- a/src/run_no_map.sh
+++ b/src/run_no_map.sh
@@ -2,13 +2,15 @@
 PWD=`pwd`
 FNP=$PWD/run_no_map_patch
 FNN=$PWD/run_no_map_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 cd $PWD
-

--- a/src/run_with_map.sh
+++ b/src/run_with_map.sh
@@ -2,12 +2,15 @@
 PWD=`pwd`
 FNP=$PWD/run_with_map_patch
 FNN=$PWD/run_with_map_numstat
-cd ~/dev/go/src/k8s.io/kubernetes/
+GITDM_HOME=${GITDM_HOME:-`cd "$(dirname "$0")/.." && pwd`}
+K8S_REPO=${K8S_REPO:-$HOME/dev/go/src/k8s.io/kubernetes/}
+CNCFDM="$GITDM_HOME/src/cncfdm.py"
+cd "$K8S_REPO"
 git config merge.renameLimit 100000
 git config diff.renameLimit 100000
 # -m --> map unknowns to 'DomainName *' , -u map unknowns to '(Unknown)'
-git log --all -p -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $FNP.html -o $FNP.txt -x $FNP.csv
-git log --all --numstat -M | ~/dev/cncf/gitdm/cncfdm.py -r '^vendor/|/vendor/|^Godeps/' -R -n -b ~/dev/cncf/gitdm/ -t -z -d -D -U -m -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
+git log --all -p -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $FNP.html -o $FNP.txt -x $FNP.csv
+git log --all --numstat -M | "$CNCFDM" -r '^vendor/|/vendor/|^Godeps/' -R -n -b "$GITDM_HOME/src/" -t -z -d -D -U -m -h $FNN.html -o $FNN.txt -x $FNN.csv > $FNN.out
 git config --unset diff.renameLimit
 git config --unset merge.renameLimit
 cd $PWD


### PR DESCRIPTION
### Summary
This PR fixes the scripts used to run gitdm analytics so they correctly locate the checked-in engine (`src/cncfdm.py`) and config base directory, and fixes the PowerShell wrapper so it works on Windows.

### Root causes
- `src/rerun_data.sh` referenced a non-existent `./all.sh`.
- Multiple runner scripts hard-coded `~/dev/cncf/gitdm/cncfdm.py` and `-b ~/dev/cncf/gitdm/`, but the repo layout uses `src/cncfdm.py` and expects `-b .../src/`.
- `gitdm.ps1` used bash heredoc syntax and did not correctly invoke `py -2` or forward piped input.

### What changed (high level)
- `gitdm.ps1`: reliable Python 2 detection/invocation and pipeline stdin passthrough.
- `src/rerun_data.sh`: call `./run_all.sh` instead of missing `./all.sh`.
- `src/run_all.sh`, `src/all_no_map.sh`, `src/all_with_map.sh`: use `GITDM_HOME` (script-relative) rather than hard-coded `~/dev/...` paths.
- `src/run_no_map.sh`, `src/run_with_map.sh`, `src/run_for_rels_no_map.sh`, `src/run_for_rels_strict.sh`, `src/anyrepo.sh`, `src/anyreporange.sh`, `src/multirepo.sh`, `src/commits_in_ranges.sh`: derive `GITDM_HOME` and use `"$GITDM_HOME/src/cncfdm.py"` with `-b "$GITDM_HOME/src/"`.

### Impact
- Restores the documented regeneration workflow (`src/rerun_data.sh`) by fixing missing/broken script targets and engine paths.
- Improves reliability for users who don’t have the repo checked out exactly at `~/dev/cncf/gitdm/`.
- Does not change the analysis logic or output formats, only how scripts locate and invoke the existing engine.

### Validation
- Verified all modified scripts now reference the repo-local engine path and no longer require a `~/dev/cncf/gitdm/cncfdm.py` file.
- On this machine I can’t run an end-to-end cncfdm execution because no Python 2/PyPy2 interpreter is installed; changes are isolated to wrappers/runner scripts and preserve existing flags/behavior.

## Confirmation
These changes are focused on correctness of script execution paths and wrapper behavior; they do not change the underlying gitdm/cncfdm analysis behavior.