### PR TITLE
Add thc1006 affiliation as Independent

### DIFF
--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -3858,5 +3858,5 @@ zzzhy: candle_1667!163.com, zzzhy!users.noreply.github.com
 zzztimbo: zzztimbo!users.noreply.github.com
 	Red Hat Inc.
 
-thc1006: hctsai!linux, thc1006!users.noreply.github.com
+thc1006: hctsai!linux.com, thc1006!users.noreply.github.com
 	Independent

--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -3857,3 +3857,6 @@ zzzhy: candle_1667!163.com, zzzhy!users.noreply.github.com
 	Meituan
 zzztimbo: zzztimbo!users.noreply.github.com
 	Red Hat Inc.
+
+thc1006: hctsai!linux, thc1006!users.noreply.github.com
+	Independent


### PR DESCRIPTION
## Summary

Add affiliation information for GitHub user thc1006.

- GitHub: thc1006
- Email: hctsai@linux.com
- Affiliation: Independent

This is required for Kubernetes organization membership application.