### PR TITLE
Add kfess user as independent

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -7965,6 +7965,8 @@ kferrone: kferrone!users.noreply.github.com
 	Independent from 2015-11-01 until 2017-03-01
 	Webaholics from 2017-03-01 until 2018-02-01
 	Akirix LLC from 2018-02-01
+kfess: g140702!gmail.com, kfess!users.noreply.github.com
+	Independent
 kfirfer: kfirfer!gmail.com, kfirfer!users.noreply.github.com
 	Independent until 2015-08-01
 	Idomoo from 2015-08-01 until 2017-03-01


### PR DESCRIPTION
Add affiliation information for GitHub user kfess.
I usually contribute to the Kubernetes project.