### PR TITLE
Add affiliation for Josh Halley at Cisco

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -1471,6 +1471,8 @@ josh-ferrell: jferrell!vmware.com, jkferr!amazon.com, josh-ferrell!users.noreply
 	VMware Inc. from 2021-07-06 until 2022-08-14
 	Amazon from 2022-08-14 until 2023-08-21
 	Adobe Inc. from 2023-08-21
+joshhalley: joshhalley!users.noreply.github.com johalley!cisco.com
+	Cisco
 josh-heyer: josh-heyer!users.noreply.github.com
 	Stack Exchange until 2020-01-01
 	EnterpriseDB from 2020-01-01


### PR DESCRIPTION
Add affiliation information for joshhalley at Cisco.

Contributing on the Virtual Kubelet project. 