### PR TITLE
Add affiliation for Richard Cunningham at Cisco

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -3135,6 +3135,8 @@ cumason123: cumason123!users.noreply.github.com
 	Holdette from 2018-09-01 until 2019-06-01
 	Refrating LLC from 2019-06-01 until 2020-05-01
 	Google LLC from 2020-05-01
+cunningr: cunningr!users.noreply.github.com cunningr!gmail.com
+	Cisco from 2005-08-01
 cunyat: cunyat.r!gmail.com
 	Peix i Marisc Ramon Cuñat until 2019-03-01
 	Agroptima from 2019-03-01 until 2020-04-01


### PR DESCRIPTION
Add affiliation information for cunningr at Cisco.

Contributing on the Virtual Kubelet project.