### PR TITLE
Remove developer affiliations for user perk-sumo

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -20864,17 +20864,6 @@ perk: marcin.stozek!canonical.com, marcin.stozek!elastic.co, marcin.stozek!gmail
 	Canonical Ltd. from 2023-09-18 until 2025-03-01
 	Independent from 2025-03-01 until 2025-10-20
 	Elasticsearch Inc. from 2025-10-20
-perk-sumo: perk-sumo!users.noreply.github.com
-	TheBookingRoom until 2010-07-01
-	International Business Machines Corporation from 2010-07-01 until 2015-08-31
-	Cinckiarz.pl from 2015-08-31 until 2017-04-30
-	Independent from 2017-04-30 until 2017-05-01
-	COLLECTIVE SENSE LLC from 2017-05-01 until 2019-11-30
-	Sumo Logic Inc. from 2019-11-30 until 2023-08-31
-	Independent from 2023-08-31 until 2023-09-18
-	Canonical Ltd. from 2023-09-18 until 2025-03-01
-	Independent from 2025-03-01 until 2025-10-20
-	Elasticsearch Inc. from 2025-10-20
 perkam: perkam!users.noreply.github.com
 	Independent until 2018-06-01
 	Warta from 2018-06-01 until 2018-09-01


### PR DESCRIPTION
It was never really used and it is redundant information to what user `perk` has anyway