### PR TITLE
Add affiliation for Ibraheem Aboulnaga at Datadog

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -12443,6 +12443,8 @@ ibragins: ibragins!redhat.com
 	Galil from 2018-06-01 until 2019-02-01
 	Independent from 2019-02-01 until 2019-05-01
 	Red Hat Inc. from 2019-05-01
+ibraheema: ibraheem.aboulnaga!datadoghq.com
+	Datadog Inc from 2024-07-01
 ibrahimhaddad: ibrahim!linux.com, ibrahimhaddad!users.noreply.github.com
 	Samsung Electronics Co. Ltd. until 2018-11-01
 	CNCF from 2018-11-01


### PR DESCRIPTION
Add affiliation information for IbraheemA at Datadog.

Contributing on the OpenTelemetry project.