### PR TITLE
Add affiliation for Morten Skriver at Cisco

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -7372,6 +7372,8 @@ moskitone: moskitone!users.noreply.github.com
 	Independent until 2015-03-01
 	EPOM from 2015-03-01 until 2019-03-01
 	MacPaw from 2019-03-01
+moskrive: moskrive!users.noreply.github.com moskrive!cisco.com
+	Cisco from 2007-08-01
 moskyb: ben!mosk.nz, moskyb!users.noreply.github.com
 	Independent until 2015-11-01
 	Flick Electric from 2015-11-01 until 2016-02-01


### PR DESCRIPTION
Add affiliation information for moskrive at Cisco.

Contributing on the Virtual Kubelet project.