### PR TITLE
Add affiliation for ddc-baiye

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -7598,6 +7598,8 @@ ddbmh: ddbmh!users.noreply.github.com, tangzmh!gmail.com
 	Alibaba Group
 ddcprg: dadelcas!hotmail.com, ddcprg!users.noreply.github.com
 	Hotels.com
+ddc-baiye: dongdong.chen!bluedotai.cn
+	BlueDot from 2025-09-24
 dddddai: dddddai!users.noreply.github.com, dddwq!foxmail.com, xdaiwenqing!gmail.com
 	Independent
 ddebasilio: ddebasilio!users.noreply.github.com


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates `developers_affiliations4.txt` to include the affiliation information for contributor `ddc-baiye`.

**Changes**:
- Added BlueDot affiliation for `ddc-baiye` (starting from 2025-09-24).

**Special notes for your reviewer**:
N/A