### PR TITLE
Add affiliation for osullivandonal

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -18007,7 +18007,7 @@ ostromart: mostrowski!google.com, ostromart!gmail.com, ostromart!users.noreply.g
 	Google LLC until 2023-11-01
 	Aviatrix from 2023-11-01
 osullivandonal: donal.osullivan!elastic.co, osullivanpatrickdonal!gmail.com
-  Elasticsearch Inc.
+	Elasticsearch Inc.
 osxi: osxi!users.noreply.github.com
 	Poetic Systems
 oszi: devel!oszi.one, oszi!users.noreply.github.com

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -18006,6 +18006,8 @@ ostrain: owen.strain!oracle.com
 ostromart: mostrowski!google.com, ostromart!gmail.com, ostromart!users.noreply.github.com
 	Google LLC until 2023-11-01
 	Aviatrix from 2023-11-01
+osullivandonal: donal.osullivan!elastic.co, osullivanpatrickdonal!gmail.com
+  Elasticsearch Inc.
 osxi: osxi!users.noreply.github.com
 	Poetic Systems
 oszi: devel!oszi.one, oszi!users.noreply.github.com


### PR DESCRIPTION
What this PR does / why we need it:
This PR updates developers_affiliations7.txt to include the affiliation information for contributor osullivandonal.

Changes:

Added Elasticsearch Inc. affiliation for osullivandonal.

Special notes for your reviewer:
N/A