### PR TITLE
update CNCF affiliation for self

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -2410,7 +2410,8 @@ craigbilner: craig.bilner!gmail.com, craigbilner!users.noreply.github.com
 craigbox: craig.box!gmail.com, craig.box!solo.io, craigb!armosec.io, craigbox!google.com, craigbox!users.noreply.github.com
 	Google LLC until 2022-10-18
 	ARMO from 2022-10-18 until 2023-11-06
-	Solo.io from 2023-11-06
+	Solo.io from 2023-11-06 until 2025-08-15
+	Independent from 2025-08-15
 craigbr: craig.bryant!hp.com, craig.bryant!hpe.com
 	HP Inc. until 2015-10-31
 	HP Inc. from 2015-10-31


### PR DESCRIPTION
Update my CNCF affiliation to independent to reflect leaving Solo to take a family sabbatical.