### PR TITLE
Remove company name abbreviation from jongwooo's affiliation

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -1337,7 +1337,7 @@ jonglae: jonglae!gmail.com
 	mdct
 jongwooo: jongwooo!users.noreply.github.com, jongwooo.han!gmail.com
 	Independent until 2026-02-23
-	Korea Financial Telecommunications & Clearings Institute (KFTC) from 2026-02-23
+	Korea Financial Telecommunications & Clearings Institute from 2026-02-23
 jongwu: jianyong.wu!arm.com, jongwu!users.noreply.github.com
 	ARM
 jonhermansen: jhermansen!ezesoft.com, jhermansen!keypr.com, jon!hermansen.dev, jon!jh86.org, jon.hermansen!gmail.com, jonhermansen!users.noreply.github.com


### PR DESCRIPTION
This pull request makes a minor update to the `developers_affiliations6.txt` file, correcting the name of an organization for clarity.

* Changed the affiliation name from "Korea Financial Telecommunications & Clearings Institute (KFTC)" to "Korea Financial Telecommunications & Clearings Institute" for the user `jongwooo`.