### PR TITLE
Bulk affiliation update for Grafana Labs org members

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -42,6 +42,8 @@
 	Codeherent Ltd from 2017-05-01 until 2017-09-01
 	STEM Learning Ltd. from 2017-09-01 until 2018-10-01
 	ControlPlane.io from 2018-10-01
+09jvilla: 9610816+09jvilla!users.noreply.github.com, 09jvilla!users.noreply.github.com
+	Grafana Labs from 2021-01-01
 0SkillAllLuck: 0SkillAllLuck!users.noreply.github.com
 	Independent until 2015-08-01
 	Swiss Post Apprenticeship from 2015-08-01 until 2019-08-01

--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -2409,6 +2409,8 @@ yuzp1996: yuzp1996!gmail.com, yuzp1996!qq.com, yuzp1996!users.noreply.github.com
 	AlaudaInc
 yvanavermaet: yvanavermaet!users.noreply.github.com
 	Independent
+yvrhdn: 7748404+yvrhdn!users.noreply.github.com, yvrhdn!users.noreply.github.com
+	Grafana Labs from 2021-04-01
 yvzsrt: yvzsrt!users.noreply.github.com
 	Argela
 ywang-pb: yun.wang!profitbricks.com
@@ -2435,6 +2437,8 @@ ywskycn: ywskycn!users.noreply.github.com
 	Independent until 2014-12-01
 	Uber from 2014-12-01 until 2018-04-01
 	ant group from 2018-04-01
+ywwg: owilliams!mixxx.org, 888940+ywwg!users.noreply.github.com, ywwg!users.noreply.github.com, owen.williams!grafana.com
+	Grafana Labs from 2021-07-01
 yxd-ym: yxd-ym!users.noreply.github.com
 	Works Applications until 2015-01-01
 	Independent from 2015-01-01 until 2015-03-01
@@ -2862,6 +2866,8 @@ zakkg3: zakkg3!gmail.com, zakkg3!users.noreply.github.com
 	ETH Zürich from 2019-06-01
 zalan-axis: zalanb!axis.com
 	Axis Communications
+zalegrala: 88330524+zalegrala!users.noreply.github.com, zalegrala!users.noreply.github.com
+	Grafana Labs from 2021-07-01
 zaletniy: github!zaletniy.me, isviridov!mirantis.com, sviridov.ilya!gmail.com
 	Mirantis Inc. until 2015-02-09
 	Independent from 2015-02-09

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -20084,6 +20084,8 @@ albers: albers!users.noreply.github.com, github!albersweb.de, github!folk.de
 	Hamburger Software GmbH & Co. KG.
 albert-dong: albert.dongfeng!huawei.com
 	Huawei Technologies Co. Ltd
+albert0fg: 86233856+albert0fg!users.noreply.github.com, albert0fg!users.noreply.github.com
+	Grafana Labs from 2025-08-01
 albertlockett: albert.lockett!solo.io, albertlockett!users.noreply.github.com
 	Independent until 2022-11-28
 	Solo.io from 2022-11-28

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -14018,6 +14018,8 @@ blencoff: blencoff!users.noreply.github.com
 	Netcracker Technology Corporation
 bleungatchromium: bleung!chromium.org
 	Google LLC
+blewis12: 164711649+blewis12!users.noreply.github.com, blewis12!users.noreply.github.com
+	Grafana Labs from 2025-09-01
 blgm: gblue!pivotal.io
 	Pivotal
 blhagadorn: blhagadorn!users.noreply.github.com
@@ -14042,6 +14044,8 @@ blind3dd: blind3dd!gmail.com, blind3dd!users.noreply.github.com
 	Independent from 2015-09-01 until 2015-12-01
 	Proximetry from 2015-12-01 until 2018-03-01
 	Codahead from 2018-03-01
+blinkuu: 40406905+blinkuu!users.noreply.github.com, blinkuu!users.noreply.github.com
+	Grafana Labs from 2022-07-01
 blisscs: blisscs!users.noreply.github.com, dev!blissweb.co
 	Independent
 blitline-dev: blitline-dev!users.noreply.github.com, support!blitline.com
@@ -15751,6 +15755,8 @@ braudel: braudel!users.noreply.github.com
 	CSR until 2015-08-01
 	Qualcomm from 2015-08-01 until 2016-02-01
 	Arm from 2016-02-01
+brauhaus-grafana: 190534435+brauhaus-grafana!users.noreply.github.com, brauhaus-grafana!users.noreply.github.com
+	Grafana Labs from 2024-12-01
 braun1928: braun1928!users.noreply.github.com
 	Intelbras until 2018-09-01
 	Independent from 2018-09-01 until 2019-01-01
@@ -19312,6 +19318,8 @@ carpnick: carpnick!users.noreply.github.com
 	HMS from 2018-01-01 until 2021-06-01
 	Cotiviti from 2021-06-01 until 2022-04-01
 	Dotmatics from 2022-04-01
+carrieedwards: 58118921+carrieedwards!users.noreply.github.com, carrieedwards!users.noreply.github.com, edwrdscarrie!gmail.com
+	Grafana Labs from 2021-09-01
 carroarmato0: carroarmato0!users.noreply.github.com
 	Memo until 2014-03-01
 	Transics from 2014-03-01 until 2014-12-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -1273,6 +1273,8 @@ codebasky: codebasky!users.noreply.github.com
 	Soroco from 2022-02-01 until 2023-02-01
 	Career Break from 2023-02-01 until 2023-04-01
 	Endor Labs from 2023-04-01
+codebien: 2103732+codebien!users.noreply.github.com, codebien!users.noreply.github.com
+	Grafana Labs from 2021-06-01
 codeblooded: codeblooded!users.noreply.github.com
 	Target until 2014-07-01
 	Independent from 2014-07-01 until 2015-05-01
@@ -1292,6 +1294,8 @@ codecalm: 1282324+codecalm!users.noreply.github.com, codecalm!gmail.com, codecal
 	84kids until 2015-11-01
 	Buddy from 2015-11-01 until 2018-06-01
 	Versum. from 2018-06-01
+codecapitano: 47627413+codecapitano!users.noreply.github.com, codecapitano!users.noreply.github.com
+	Grafana Labs from 2023-01-01
 codeclown: codeclown!users.noreply.github.com, martti!codeclown.net
 	Independent until 2014-10-01
 	ID BBN from 2014-10-01 until 2017-06-01
@@ -1857,6 +1861,8 @@ concaf: concaf!users.noreply.github.com, shubham!linux.com
 	Ambassador from 2018-05-01
 concubidated: tbrekke!redhat.com
 	Red Hat Inc.
+condla: 4442327+condla!users.noreply.github.com, condla!users.noreply.github.com
+	Grafana Labs from 2021-08-01
 condorcet: condorcet!users.noreply.github.com, novikov.vz!gmail.com
 	Independent until 2019-03-01
 	Digital Design from 2019-03-01
@@ -6072,6 +6078,8 @@ dansiviter: dansiviter!users.noreply.github.com
 dansomething: dansomething!users.noreply.github.com
 	ReadyTalk until 2016-06-01
 	Power Pro Leasing from 2016-06-01
+danstadler-pdx: 10214489+danstadler-pdx!users.noreply.github.com, danstadler-pdx!users.noreply.github.com
+	Grafana Labs from 2022-09-01
 dantehemerson: dantehemerson!users.noreply.github.com
 	Independent until 2019-01-01
 	TiSmart from 2019-01-01 until 2019-09-01
@@ -10102,8 +10110,9 @@ dguitarbite: dguitarbite!gmail.com
 dgurindapalli: dgurindapalli!users.noreply.github.com, gkumar0605!gmail.com
 	hCentive until 2014-12-01
 	DigitalBytes from 2014-12-01
-dgzlopes: daniel!gonzalezlopes.com, dgzlopes!users.noreply.github.com
-	Independent
+dgzlopes: daniel!gonzalezlopes.com, 8228060+dgzlopes!users.noreply.github.com, dgzlopes!users.noreply.github.com
+	Independent until 2021-06-01
+	Grafana Labs from 2021-06-01
 dh185221: dh185221!ncr.com
 	International Business Machines Corporation until 2021-08-01
 	NCR Retail Solutions from 2021-08-01
@@ -20151,6 +20160,8 @@ eskaufel: eskaufel!users.noreply.github.com, espen.skaufel!verent.no
 	Helsedirektoratet from 2015-06-01 until 2016-10-01
 	Acando Norge from 2016-10-01 until 2019-03-01
 	DNV GL - Maritime from 2019-03-01
+eskirk: 7052378+eskirk!users.noreply.github.com, eskirk!users.noreply.github.com
+	Grafana Labs from 2022-09-01
 eslam-gomaa: eslam-gomaa!users.noreply.github.com
 	Independent until 2015-11-01
 	Raya from 2015-11-01 until 2016-01-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -507,6 +507,8 @@ francoispqt: francois.parquet!gmail.com, francoispqt!users.noreply.github.com
 	Heetch from 2019-08-01 until 2020-09-01
 	BlaBlaCar from 2020-09-01 until 2022-04-01
 	Wave Mobile Money Permanent from 2022-04-01
+francoposa: franco!francoposa.io, 13006869+francoposa!users.noreply.github.com, francoposa!users.noreply.github.com
+	Grafana Labs from 2023-05-01
 francostellari: francostellari!users.noreply.github.com
 	International Business Machines Corporation
 francotiveron: franco.tiveron!gmail.com
@@ -657,6 +659,8 @@ fraserdarwent: fraser!darwen.tf, fraserdarwent!users.noreply.github.com
 	Contino from 2019-02-01
 frasertweedale: frase!frase.id.au, frasertweedale!users.noreply.github.com, ftweedal!redhat.com
 	Red Hat Inc.
+fratcliffe: 8361541+fratcliffe!users.noreply.github.com, fratcliffe!users.noreply.github.com
+	Grafana Labs from 2025-04-01
 frauniki: frauniki!sinoa.jp, frauniki!users.noreply.github.com
 	freee
 frawang: frank.wang!rock-chips.com
@@ -7978,9 +7982,10 @@ haircommander: haircommander!users.noreply.github.com, pehunt!redhat.com
 	Red Hat Inc.
 hairmare: hairmare!purplehaze.ch, hairmare!users.noreply.github.com, lucas.bickel!adfinis-sygroup.ch
 	Independent
-hairyhenderson: dhenderson!gmail.com, hairyhenderson!users.noreply.github.com
+hairyhenderson: dhenderson!gmail.com, 2037086+hairyhenderson!users.noreply.github.com, hairyhenderson!users.noreply.github.com
 	International Business Machines Corporation until 2015-05-01
-	QlikTech International AB from 2015-05-01
+	QlikTech International AB from 2015-05-01 until 2021-01-01
+	Grafana Labs from 2021-01-01
 haitch: haidaocht!gmail.com, haitch!microsoft.com, haitch!users.noreply.github.com
 	Independent until 2013-08-01
 	Microsoft Corporation from 2013-08-01
@@ -9595,6 +9600,8 @@ heimweh: alexander.hellbom!gmail.com, heimweh!users.noreply.github.com
 	TIER Mobility from 2019-10-01
 heitorlessa: heitor.lessa!hotmail.com
 	Amazon
+heitortsergent: 446316+heitortsergent!users.noreply.github.com, heitortsergent!users.noreply.github.com
+	Grafana Labs from 2023-06-01
 hejingkan2005: jahe!microsoft.com
 	Microsoft Corporation
 hekaldama: aavilla!yp.com, hekaldama!users.noreply.github.com
@@ -15449,6 +15456,8 @@ ishangupta-ds: ishan!chaosnative.com, ishan.gupta!mayadata.io, ishangupta-ds!use
 	Google LLC from 2019-04-01 until 2020-05-01
 	MayaData Inc. (f/k/a CloudByte Inc) from 2020-05-01 until 2021-02-01
 	ChaosNative from 2021-02-01
+ishanjainn: 51803183+ishanjainn!users.noreply.github.com, ishanjainn!users.noreply.github.com
+	Grafana Labs from 2022-05-01
 ishankhare07: ishankhare07!gmail.com, ishankhare07!users.noreply.github.com
 	Independent until 2015-06-01
 	Codemancers from 2015-06-01 until 2015-08-01
@@ -15859,6 +15868,8 @@ itscert: itscert!users.noreply.github.com
 	Accuknox from 2020-06-01
 itsderek23: derek!scoutapp.com, derek.haynes!gmail.com, itsderek23!users.noreply.github.com
 	Scout
+itsgareth: 34524710+itsgareth!users.noreply.github.com, itsgareth!users.noreply.github.com
+	Grafana Labs from 2022-08-01
 itsjaspermilan: itsjaspermilan!users.noreply.github.com
 	Independent until 2015-02-01
 	BarBurrito from 2015-02-01 until 2017-12-01
@@ -18707,6 +18718,8 @@ javiermarasco: javiermarasco!users.noreply.github.com
 	Amadeus from 2016-07-01 until 2020-12-01
 	Schuberg Philis from 2020-12-01 until 2021-11-01
 	Amadeus from 2021-11-01
+javiermolinar: 10704736+javiermolinar!users.noreply.github.com, javiermolinar!users.noreply.github.com
+	Grafana Labs from 2024-06-01
 javierpena: jpena!redhat.com, korzhuev!andrusha.me, matthew.molnar!gmail.com
 	Red Hat Inc.
 javierruizjimenez: jruiz!itwonderlab.com
@@ -19628,6 +19641,8 @@ jcpowermac: jcallen!redhat.com, jcpowermac!gmail.com, jcpowermac!users.noreply.g
 	Red Hat Inc.
 jcpunk: jcpunk!users.noreply.github.com, riehecky!fnal.gov
 	Fermilab
+jcreixell: 1193802+jcreixell!users.noreply.github.com, jcreixell!users.noreply.github.com
+	Grafana Labs from 2022-08-01
 jcrosel: jcrosel!users.noreply.github.com
 	Independent until 2014-07-01
 	BearingPoint GmbH from 2014-07-01 until 2014-08-01
@@ -21082,6 +21097,8 @@ jesusfcr: jesusfcr!users.noreply.github.com
 	Finteca from 2019-02-01 until 2019-06-01
 	Independent from 2019-06-01 until 2019-10-01
 	Adevinta from 2019-10-01
+jesusvazquez: jesusvzpg!gmail.com, 2439858+jesusvazquez!users.noreply.github.com, jesusvazquez!users.noreply.github.com
+	Grafana Labs from 2021-01-01
 jeswanke: jeswanke!users.noreply.github.com
 	International Business Machines Corporation
 jeswinkoshyninan: jeswinkoshyninan!users.noreply.github.com
@@ -23516,12 +23533,13 @@ jmhwang7: jmhwang7!users.noreply.github.com
 	Stripe Inc. from 2019-06-01 until 2020-10-01
 	Independent from 2020-10-01 until 2021-02-01
 	Render from 2021-02-01
-jmichalek132: jmichalek132!users.noreply.github.com
+jmichalek132: 7171250+jmichalek132!users.noreply.github.com, jmichalek132!users.noreply.github.com
 	Independent until 2017-06-01
 	Ringier Axel Springer SK from 2017-06-01 until 2017-09-01
 	Independent from 2017-09-01 until 2018-02-01
 	Seznam.cz a.s. from 2018-02-01 until 2020-05-01
-	Medallia from 2020-05-01
+	Medallia from 2020-05-01 until 2025-06-01
+	Grafana Labs from 2025-06-01
 jmickey: github!mickey.dev, jmickey!users.noreply.github.com, josh.michielsen!weave.works
 	Cancer Council Western Australia until 2015-11-01
 	Office Solutions from 2015-11-01 until 2017-01-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -3083,6 +3083,8 @@ jracollins: jracollins!gmail.com, jracollins!users.noreply.github.com
 	YOOX NET A PORTER GROUP SPA from 2016-09-01 until 2019-08-01
 	Independent from 2019-08-01 until 2021-03-01
 	AGORA from 2021-03-01
+jradhakrishnan: 18289983+jradhakrishnan!users.noreply.github.com, jradhakrishnan!users.noreply.github.com, radhakrishnan.jankiraman!gmail.com
+	Grafana Labs from 2023-09-01
 jragula-zs: jragula-zs!users.noreply.github.com
 	Ivy until 2019-08-01
 	McAfee from 2019-08-01 until 2021-08-01
@@ -4502,11 +4504,12 @@ juliusdanielherreraglomm: juliusdanielherreraglomm!users.noreply.github.com
 	Independent from 2022-09-01
 juliusl: juliusl!microsoft.com, juliusl!users.noreply.github.com
 	Microsoft Corporation
-juliusmh: juliusmh!web.de
+juliusmh: juliusmh!web.de, 7480158+juliusmh!users.noreply.github.com, juliusmh!users.noreply.github.com
 	Independent until 2019-01-01
 	gridX from 2019-01-01 until 2023-08-01
 	Working from 2023-08-01 until 2023-10-01
-	Cisco Systems Inc. from 2023-10-01
+	Cisco Systems Inc. from 2023-10-01 until 2025-06-01
+	Grafana Labs from 2025-06-01
 juliusmilan: jmilan!redhat.com, juliusmilan!users.noreply.github.com
 	Red Hat Inc.
 juliusrickert: me!juliusrickert.de
@@ -6055,6 +6058,8 @@ kalis2: kalis!netapp.com
 	NetApp Inc
 kalise: kalise!users.noreply.github.com
 	Independent
+kalleep: kalle.persson92!gmail.com, 23356117+kalleep!users.noreply.github.com, kalleep!users.noreply.github.com
+	Grafana Labs from 2021-05-01
 kallependers: kallependers!users.noreply.github.com
 	DPG until 2021-10-01
 	MyParcel from 2021-10-01
@@ -11011,6 +11016,8 @@ kornholi: kornholi!users.noreply.github.com
 	AvatroMB from 2021-12-01
 korniltsev: anatoly.korniltsev!grafana.com, korniltsev!users.noreply.github.com, korniltsev.anatoly!gmail.com
 	Grafana Labs
+korniltsev-grafanista: 229453617+korniltsev-grafanista!users.noreply.github.com, korniltsev-grafanista!users.noreply.github.com
+	Grafana Labs from 2023-05-01
 kornys: kornys!outlook.com, kornys!users.noreply.github.com
 	Red Hat Inc.
 korovkin: korovkin!gmail.com, korovkin!users.noreply.github.com
@@ -12247,11 +12254,12 @@ kuhlenh: kaseyu!microsoft.com
 kuhnroyal: kuhnroyal!users.noreply.github.com, p.leibiger!codecraft.de
 	CodeCraft until 2019-05-01
 	source.kitchen from 2019-05-01
-kuiperda: kuiperda!users.noreply.github.com
+kuiperda: 44123852+kuiperda!users.noreply.github.com, kuiperda!users.noreply.github.com
 	Independent until 2021-05-01
 	Career Break from 2021-05-01 until 2022-05-01
 	Independent from 2022-05-01 until 2023-01-01
-	observIQ from 2023-01-01
+	observIQ from 2023-01-01 until 2026-02-01
+	Grafana Labs from 2026-02-01
 kuisathaverat: kuisathaverat!users.noreply.github.com, kuisathaverat!yahoo.com
 	Abengoa until 2015-12-01
 	CloudBees Inc. from 2015-12-01 until 2018-08-01
@@ -14257,6 +14265,8 @@ ldts: jorge.ramirez-ortiz!linaro.org, jorge.ramirez.ortiz!gmail.com
 	Linaro Limited
 ldu4: ldufour!linux.vnet.ibm.com
 	International Business Machines Corporation
+ldufr: 1349199+ldufr!users.noreply.github.com, ldufr!users.noreply.github.com
+	Grafana Labs from 2025-10-01
 ldunkum: ldunkum!users.noreply.github.com
 	Independent
 lduparc: lduparc!users.noreply.github.com
@@ -22289,6 +22299,8 @@ markns: markns!users.noreply.github.com
 	Optiver until 2017-07-01
 	Gridarrow from 2017-07-01 until 2019-02-01
 	Flow Traders from 2019-02-01
+markobachvarovski: 61027250+markobachvarovski!users.noreply.github.com, markobachvarovski!users.noreply.github.com, marko.bachvarovski!grafana.com
+	Grafana Labs from 2025-09-01
 markoskandylis: markoskandylis!users.noreply.github.com
 	Pret A Manger until 2018-11-01
 	Equinix Inc. from 2018-11-01 until 2020-01-01
@@ -22764,9 +22776,10 @@ martinkennelly: martinkennelly!users.noreply.github.com
 	Red Hat Inc. from 2021-07-01
 martinknechtel: martinknechtel!users.noreply.github.com
 	SAP
-martinkuba: martinkuba!users.noreply.github.com, mkuba!newrelic.com
+martinkuba: 4933147+martinkuba!users.noreply.github.com, martinkuba!users.noreply.github.com, mkuba!newrelic.com, martin!martinkuba.com
 	Independent until 2015-09-01
-	New Relic Inc. from 2015-09-01
+	New Relic Inc. from 2015-09-01 until 2025-07-01
+	Grafana Labs from 2025-07-01
 martinlevesque: martinlevesque!users.noreply.github.com
 	Independent until 2015-08-01
 	IOU Financial from 2015-08-01 until 2016-05-01
@@ -23109,6 +23122,8 @@ masseybradley: massey.bradley!gmail.com, masseybradley!users.noreply.github.com
 	ADNEOM from 2015-04-01 until 2015-05-01
 	EastNets from 2015-05-01 until 2019-04-01
 	Yields.io from 2019-04-01
+masslessparticle: 1413241+masslessparticle!users.noreply.github.com, masslessparticle!users.noreply.github.com
+	Grafana Labs from 2021-04-01
 massoudasadi: massoud.asadi!hotmail.com
 	Independent until 2017-06-01
 	Sahand Hydraulics from 2017-06-01 until 2017-07-01
@@ -23727,6 +23742,8 @@ mattdodge: mattdodge!users.noreply.github.com
 	LoanSnap from 2019-07-01
 mattdoran: matt.doran!papercut.com, mattdoran!users.noreply.github.com, mattdoran76!gmail.com
 	PaperCut Software
+mattdurham: 3036838+mattdurham!users.noreply.github.com, mattdurham!users.noreply.github.com
+	Grafana Labs from 2020-12-01
 matteocastellotti: matteo.castellotti!gmail.com, matteocastellotti!users.noreply.github.com
 	Sanmarco until 2017-06-01
 	OMNYS Information from 2017-06-01 until 2020-07-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -1315,10 +1315,11 @@ mbarrien: mbarrien!users.noreply.github.com, mike!syapse.com
 mbasmanova: mbasmanova!users.noreply.github.com
 	VMware Inc. until 2014-09-01
 	Meta Platforms Inc. from 2014-09-01
-mbaykara: mbaykara!users.noreply.github.com, mehmetalibaykara!gmail.com
+mbaykara: 31475871+mbaykara!users.noreply.github.com, mbaykara!users.noreply.github.com, mehmetalibaykara!gmail.com
 	Independent until 2019-04-01
 	encoway from 2019-04-01 until 2021-01-01
-	TeamViewer from 2021-01-01
+	TeamViewer from 2021-01-01 until 2024-09-01
+	Grafana Labs from 2024-09-01
 mbbroberg: 1744971+mbbroberg!users.noreply.github.com, mbbroberg!users.noreply.github.com
 	Infinio until 2014-12-01
 	Basho from 2014-12-01 until 2015-12-01
@@ -9579,11 +9580,12 @@ mstsirkin: mst!redhat.com
 	Red Hat Inc.
 mstump: mrevilgnome!gmail.com, mstump!users.noreply.github.com
 	Vorstella Corp
-mstumpfx: mstumpf!signalfx.com, mstumpfx!users.noreply.github.com
+mstumpfx: mstumpf!signalfx.com, 31015658+mstumpfx!users.noreply.github.com, mstumpfx!users.noreply.github.com
 	Elster until 2015-09-01
 	Independent from 2015-09-01 until 2017-08-01
 	SignalFx Inc. from 2017-08-01 until 2019-10-01
-	Splunk Inc. from 2019-10-01
+	Splunk Inc. from 2019-10-01 until 2024-11-01
+	Grafana Labs from 2024-11-01
 msukalski: mitch.sukalski!gmail.com, mitch.sukalski!workday.com, msukalski!users.noreply.github.com
 	Pertino until 2015-12-01
 	Cradlepoint Inc from 2015-12-01 until 2019-01-01
@@ -11151,6 +11153,8 @@ nadiaciobanu: nadiaciobanu!users.noreply.github.com
 	Independent from 2019-08-01 until 2020-05-01
 	Google LLC from 2020-05-01 until 2020-08-01
 	Independent from 2020-08-01
+nadiamoe: 969721+nadiamoe!users.noreply.github.com, nadiamoe!users.noreply.github.com
+	Grafana Labs from 2023-04-01
 nadiatk: natkach!microsoft.com
 	Microsoft Corporation
 nadihagh: nadihagh!users.noreply.github.com, sina.nadihagh!gmail.com
@@ -13921,6 +13925,8 @@ nicolerenee: nicole!nicolerenee.io, nicolerenee!users.noreply.github.com
 	WPEngine Inc.
 nicolethoen: nicolemthoen!gmail.com, nicolethoen!users.noreply.github.com, nthoen!redhat.com
 	Red Hat Inc.
+nicolevanderhoeven: 36070553+nicolevanderhoeven!users.noreply.github.com, nicolevanderhoeven!users.noreply.github.com
+	Grafana Labs from 2021-06-01
 nicolo-ribaudo: nicolo-ribaudo!users.noreply.github.com, nicolo.ribaudo!gmail.com
 	Independent until 2017-08-01
 	BabelJS from 2017-08-01
@@ -15096,6 +15102,8 @@ njuettner: hello!juni.io, nick!juni.io, nick!zalando.de, nick.juettner!zalando.d
 	Giant Swarm GmbH from 2020-04-01
 njuicsgz: gaozheng0123!163.com, njuicsgz!users.noreply.github.com
 	NetEase Inc
+njvrzm: 19716792+njvrzm!users.noreply.github.com, njvrzm!users.noreply.github.com
+	Grafana Labs from 2024-01-01
 nkanish2002: nkanish2002!users.noreply.github.com
 	Boeing until 2014-12-01
 	Symantec Corporation from 2014-12-01 until 2015-11-01
@@ -15900,6 +15908,8 @@ nparfait: nparfait!users.noreply.github.com
 npaton: npaton!users.noreply.github.com
 	Consultant until 2017-12-01
 	MantisNet from 2017-12-01
+npazosmendez: 32206519+npazosmendez!users.noreply.github.com, npazosmendez!users.noreply.github.com
+	Grafana Labs from 2022-06-01
 npdgm: npdgm!users.noreply.github.com
 	Enix SAS
 npentrel: npentrel!users.noreply.github.com
@@ -16699,6 +16709,8 @@ obeleh: obeleh!users.noreply.github.com, sjanssen!insign.it
 	Kabisa B.V. from 2018-12-01
 oberpar: oberpar!linux.ibm.com, oberpar!linux.vnet.ibm.com
 	International Business Machines Corporation
+obetomuniz: 1680157+obetomuniz!users.noreply.github.com, obetomuniz!users.noreply.github.com
+	Grafana Labs from 2022-06-01
 obeyda: djefobey!gmail.com, obeyda!users.noreply.github.com
 	Independent until 2016-06-01
 	Redfabriq from 2016-06-01 until 2017-02-01
@@ -17367,6 +17379,8 @@ oleg-filiutsich: oleg-filiutsich!users.noreply.github.com
 	EPAM Systems Inc until 2017-02-01
 	IDFinance from 2017-02-01 until 2019-10-01
 	Stark Games from 2019-10-01
+oleg-kozlyuk-grafana: 229985674+oleg-kozlyuk-grafana!users.noreply.github.com, oleg-kozlyuk-grafana!users.noreply.github.com
+	Grafana Labs from 2025-09-01
 oleg-nenashev: kim!letkeman.net, nenashev!synopsys.com, o.v.nenashev!gmail.com
 	Independent until 2015-04-01
 	CloudBees Inc. from 2015-04-01
@@ -22139,11 +22153,12 @@ petethepig: dmitry.filimonov!grafana.com, petethepig!users.noreply.github.com
 petetnt: pete.a.nykanen!gmail.com, petelive138!gmail.com, petetnt!users.noreply.github.com
 	Upknowledge until 2016-04-01
 	Motley Agency from 2016-04-01
-petewall: petewall!users.noreply.github.com
+petewall: 2235675+petewall!users.noreply.github.com, petewall!users.noreply.github.com
 	Sift Limited group until 2016-09-01
 	AREA15 from 2016-09-01 until 2018-06-01
 	Pivotal from 2018-06-01 until 2020-01-01
-	VMware Inc. from 2020-01-01
+	VMware Inc. from 2020-01-01 until 2023-01-01
+	Grafana Labs from 2023-01-01
 petewarden: pete!petewarden.com
 	Google LLC
 petkaantonov: petka.antonov!gmail.com, petka_antonov!hotmail.com, petkaantonov!users.noreply.github.com

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -608,8 +608,9 @@ portellaa: lcportellaa!gmail.com, portellaa!users.noreply.github.com
 	YData from 2020-02-01
 portepa: porte.pierreantoine!gmail.com, portepa!users.noreply.github.com
 	Pivotal
-portertech: portertech!gmail.com, portertech!users.noreply.github.com
-	Sensu Inc
+portertech: portertech!gmail.com, 149630+portertech!users.noreply.github.com, portertech!users.noreply.github.com
+	Sensu Inc until 2024-08-01
+	Grafana Labs from 2024-08-01
 portovep: portovep!tcd.ie
 	ThoughtWorks Inc
 pose: albertopose!gmail.com, pose!users.noreply.github.com
@@ -3972,6 +3973,8 @@ rafa-acioly: aciolyr!gmail.com, rafa-acioly!users.noreply.github.com
 	Independent from 2020-08-01 until 2020-10-01
 	Gympass from 2020-10-01 until 2022-07-01
 	Grupo Boticário from 2022-07-01
+rafa-munoz: 23944+rafa-munoz!users.noreply.github.com, rafa-munoz!users.noreply.github.com
+	Grafana Labs from 2021-06-01
 rafabene: benevides!redhat.com, pgrepps!savi.com, rafabene!gmail.com, rafabene!users.noreply.github.com, vladimirfol!gmail.com, yogeshkumar180592!gmail.com
 	Red Hat Inc.
 rafadc: rafadc!users.noreply.github.com, rafael!micubiculo.com
@@ -9184,6 +9187,8 @@ robert-cronin: robert!robertcronin.com, robert.cronin!uqconnect.edu.au, robert.o
 	Microsoft Corporation
 robert-hoo: robert.hu!intel.com
 	Intel Corporation
+robert-northmind: 59053438+robert-northmind!users.noreply.github.com, robert-northmind!users.noreply.github.com
+	Grafana Labs from 2024-01-01
 robert-shade: robert.shade!gmail.com
 	Coleman Technologies Inc. until 2018-01-01
 	Presidio Inc. from 2018-01-01 until 2018-02-01
@@ -10194,8 +10199,9 @@ roi-codefresh: roi-codefresh!users.noreply.github.com
 	Codefresh Inc. from 2020-02-01
 roidayan: roid!mellanox.com
 	Mellanox
-roidelapluie: roidelapluie!gmail.com, roidelapluie!inuits.eu, roidelapluie!users.noreply.github.com
-	Inuits
+roidelapluie: roidelapluie!gmail.com, roidelapluie!inuits.eu, 291750+roidelapluie!users.noreply.github.com, roidelapluie!users.noreply.github.com
+	Inuits until 2025-03-01
+	Grafana Labs from 2025-03-01
 roiravhon: roi!roiravhon.com
 	Logshero Ltd.
 roivaz: roivaz!users.noreply.github.com, roivazquez!gmail.com
@@ -11906,6 +11912,8 @@ ruskofd: ruskofd!users.noreply.github.com
 	CESI from 2019-02-01 until 2020-07-01
 	SIA Worldline Latvia from 2020-07-01 until 2023-04-01
 	ADEO from 2023-04-01
+ruslan-mikhailov: 195758209+ruslan-mikhailov!users.noreply.github.com, ruslan-mikhailov!users.noreply.github.com
+	Grafana Labs from 2025-02-01
 ruslantum: ruslantum!users.noreply.github.com
 	Silpion IT
 russellb: rbryant!redhat.com, russell!russellbryant.net, russellb!users.noreply.github.com
@@ -16388,8 +16396,9 @@ sd-buildbot: sd-buildbot!users.noreply.github.com
 	b
 sd-buildbot-functional: sd-buildbot-functional!users.noreply.github.com
 	b
-sd2k: ben.sully!yougov.com, ben.sully88!gmail.com, jginsburgn!gmail.com, sd2k!users.noreply.github.com
-	YouGov
+sd2k: ben.sully!yougov.com, ben.sully88!gmail.com, jginsburgn!gmail.com, 5464991+sd2k!users.noreply.github.com, sd2k!users.noreply.github.com
+	YouGov until 2021-02-01
+	Grafana Labs from 2021-02-01
 sdadh01: sdadh01!users.noreply.github.com
 	techopsguru
 sdague: sdague!users.noreply.github.com, sean!dague.net
@@ -16558,6 +16567,8 @@ sealmove: sealmove!users.noreply.github.com
 	Incelligent from 2023-01-01
 seamounts: 15010828953!163.com, seamounts!users.noreply.github.com
 	NetEase Inc
+seamusgrafana: 102023327+seamusgrafana!users.noreply.github.com, seamusgrafana!users.noreply.github.com
+	Grafana Labs from 2022-03-01
 sean-: sean!chittenden.org, sean-!users.noreply.github.com
 	HashiCorp Inc
 sean-jc: sean.j.christopherson!intel.com

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -1229,6 +1229,8 @@ src-code: src-code!users.noreply.github.com
 	Yahoo! Inc. from 2021-09-01
 srcLurker: css!google.com
 	Google LLC
+srclosson: 7053010+srclosson!users.noreply.github.com, srclosson!users.noreply.github.com, srclosson!gmail.com
+	Grafana Labs from 2019-09-01
 sre: sebastian.reichel!collabora.co.uk, sebastian.reichel!collabora.com, sre!debian.org, sre!kernel.org, sre!ring0.de
 	Debian until 2017-04-01
 	Independent from 2017-04-01
@@ -7298,10 +7300,11 @@ tedsmitt: ed!edintheclouds.io
 	OBT Live from 2019-08-01
 tedsteen: ted.steen!gmail.com
 	Independent
-tedsuo: ted!lightstep.com, tedsuo!users.noreply.github.com
+tedsuo: ted!lightstep.com, 24074+tedsuo!users.noreply.github.com, tedsuo!users.noreply.github.com, ted!tedsuo.com
 	Pivotal until 2016-10-01
 	Independent from 2016-10-01 until 2017-01-01
-	LightStep Inc. from 2017-01-01
+	LightStep Inc. from 2017-01-01 until 2025-03-01
+	Grafana Labs from 2025-03-01
 tedtramonte: tedtramonte!users.noreply.github.com
 	J.Crew until 2015-12-01
 	Independent from 2015-12-01 until 2016-07-01
@@ -11186,6 +11189,8 @@ toddnni: toddnni!users.noreply.github.com, toni.ylenius!cybercom.com
 	Cybercom Group AB
 toddpoynor: toddpoynor!google.com, toddpoynor!users.noreply.github.com
 	Google LLC
+toddtreece: 360020+toddtreece!users.noreply.github.com, toddtreece!users.noreply.github.com
+	Grafana Labs from 2021-04-01
 toddysm: toddysm!users.noreply.github.com
 	Agitare until 2020-03-14
 	Microsoft Corporation from 2020-03-14
@@ -11427,6 +11432,8 @@ tomberget: tomberget!users.noreply.github.com, toms.berget!gmail.com
 	TietoEVRY from 2021-01-01
 tombokombo: tombokombo!users.noreply.github.com
 	SysArt
+tombrk: 26971117+tombrk!users.noreply.github.com, tombrk!users.noreply.github.com
+	Grafana Labs from 2019-07-01
 tombruijn: tom!tomdebruijn.com, tombruijn!users.noreply.github.com
 	Keplar Agency until 2016-07-01
 	Independent from 2016-07-01 until 2018-04-01
@@ -11453,6 +11460,8 @@ tombuuz: ldagvanorov!gmail.com
 tomchwojkofrank: tomchwojkofrank!users.noreply.github.com
 	VP of R&D until 2016-11-01
 	Independent from 2016-11-01
+tomclqncy: 10931458+tomclqncy!users.noreply.github.com, tomclqncy!users.noreply.github.com
+	Grafana Labs from 2022-10-01
 tomconte: tomconte!users.noreply.github.com
 	Microsoft Corporation
 tomcruise81: tomcruise81!users.noreply.github.com
@@ -16281,6 +16290,8 @@ verdverm: verdverm!users.noreply.github.com
 	Independent from 2017-06-01 until 2019-06-01
 	Ferrum Health from 2019-06-01 until 2019-10-01
 	Astronomer from 2019-10-01
+verejoel: 46783161+verejoel!users.noreply.github.com, verejoel!users.noreply.github.com
+	Grafana Labs from 2025-11-01
 verma-kunal: verma-kunal!users.noreply.github.com
 	Independent until 2021-07-01
 	Community Classroom from 2021-07-01 until 2021-09-01
@@ -18291,6 +18302,8 @@ vmr1532: vmr1532!users.noreply.github.com
 	Meta Platforms Inc. from 2021-08-01
 vmsh0: vmsh0!users.noreply.github.com
 	Independent
+vmtocloud: 10639221+vmtocloud!users.noreply.github.com, vmtocloud!users.noreply.github.com
+	Grafana Labs from 2024-11-01
 vmtyler: tbritten!us.ibm.com, vmtyler!users.noreply.github.com
 	EMC until 2015-06-30
 	Blue Box Group from 2015-06-30


### PR DESCRIPTION
Discussed this in #1010

This is a bulk update attributing OpenTelemetry contributions to Grafana Labs for 59 current Grafana employees whose affiliations were missing or incorrect. For each contributor, both GitHub noreply email formats are included (`ID+username@users.noreply.github.com` and `username@users.noreply.github.com`) to cover accounts created before and after GitHub's July 2017 format change. Additionally, personal emails are included in cases where requested. Grafana Labs start dates are derived from internal employee onboarding metadata.

I've already spoken to all of these people via internal communication, but tagging them here as well for addition visibility. 

@09jvilla @albert0fg @blewis12 @blinkuu @brauhaus-grafana
@carrieedwards @codebien @codecapitano @condla @danstadler-pdx @dgzlopes @eskirk
@francoposa @fratcliffe @gouthamve-but-enterprise @hairyhenderson
@heitortsergent @ishanjainn @itsgareth @javiermolinar @jcreixell @jesusvazquez
@jmichalek132 @jradhakrishnan @juliusmh @kalleep @korniltsev-grafanista
@kuiperda @ldufr @markobachvarovski @martinkuba @masslessparticle @mattdurham
@mbaykara @mstumpfx @nadiamoe @nicolevanderhoeven @njvrzm
@npazosmendez @obetomuniz @oleg-kozlyuk-grafana @petewall @portertech
@rafa-munoz @robert-northmind @roidelapluie @ruslan-mikhailov @sd2k
@seamusgrafana @srclosson @tedsuo @toddtreece @tombrk @tomclqncy @verejoel
@vmtocloud @yvrhdn @ywwg @zalegrala