### PR TITLE
Modify bergerx affiliations and add new entries

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -12105,11 +12105,15 @@ bergerhoffer: bergerhoffer!users.noreply.github.com
 bergeron: bergeron!users.noreply.github.com, brian.e.bergeron!gmail.com
 	Independent until 2015-05-01
 	Microsoft Corporation from 2015-05-01
-bergerx: bekirdo!gmail.com, bergerx!users.noreply.github.com
-	Amazon until 2016-01-01
+bergerx: bekirdo!gmail.com, bergerx!users.noreply.github.com, bekir.dogan!servicenow.com
+	Independent until 2013-10-01
+	Amazon from 2013-10-01 until 2016-01-01
 	Independent from 2016-01-01 until 2016-05-01
 	IAC Publishing from 2016-05-01 until 2016-11-01
-	PTC Inc. from 2016-11-01
+	PTC Inc. from 2016-11-01 until 2022-06-01
+	VMware Inc. from 2022-06-01 until 2025-07-01
+	Independent from 2025-07-01 until 2026-02-01
+	ServiceNow from 2026-02-01
 bergkvist: bergkvist!users.noreply.github.com, tobias!bergkv.ist
 	Skien kommune until 2015-08-01
 	Independent from 2015-08-01 until 2017-06-01


### PR DESCRIPTION
Updated affiliations for bergerx to include ServiceNow and VMware.