### PR TITLE
Update pierluigilenoci affiliation emails

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -23478,7 +23478,7 @@ pierluc-codes: pierluc-codes!users.noreply.github.com
 	hims & hers from 2019-04-01 until 2020-02-01
 	Shopify Inc. from 2020-02-01 until 2022-08-01
 	HashiCorp Inc from 2022-08-01
-pierluigilenoci: pierluigilenoci!users.noreply.github.com
+pierluigilenoci: pierluigilenoci!users.noreply.github.com, pierluigi.lenoci!gmail.com, pierluigi.lenoci!sap.com
 	GruppoMeta until 2016-07-01
 	GLOSSYBOX from 2016-07-01 until 2018-01-01
 	Akelius Residential Property AB from 2018-01-01 until 2022-04-01


### PR DESCRIPTION
## Summary
- Add personal (`pierluigi.lenoci!gmail.com`) and SAP (`pierluigi.lenoci!sap.com`) email addresses to existing `pierluigilenoci` entry in `developers_affiliations7.txt`
- Current affiliation (SAP from 2022-04-01) remains unchanged