### PR TITLE
Add jeffbearer affiliation (Microsoft)

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -20546,6 +20546,8 @@ jeffbcross: jeffbcross!users.noreply.github.com, middlefloor!gmail.com, zhbhun!g
 jeffbean: jeff.bean!hds.com, jeffbean!users.noreply.github.com, jeffreyrobertbean!gmail.com
 	Hitachi Ltd. until 2016-02-01
 	Uber from 2016-02-01
+jeffbearer: jebearer!microsoft.com, jeffbearer!users.noreply.github.com
+        Microsoft
 jeffbski: filippominutella!gmail.com, jeff.barczewski!gmail.com, jeffbski!users.noreply.github.com
 	CodeWinds until 2018-09-01
 	Sketch Development from 2018-09-01


### PR DESCRIPTION
Add developer affiliation for [jeffbearer](https://github.com/jeffbearer) — Microsoft.

Contributing to [kubernetes-sigs/azurelustre-csi-driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) (SIG Cloud Provider, provider-azure subproject).