### PR TITLE
Update raykrueger affiliation to Spectro Cloud

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -6243,7 +6243,8 @@ raykao: raykao!users.noreply.github.com
 	People & Code until 2016-09-01
 	Microsoft Corporation from 2016-09-01
 raykrueger: raykrueger!gmail.com, raykrueger!users.noreply.github.com
-	Amazon
+	Spectro Cloud
+	Amazon until 2025-09-30
 raymondchen625: raymondchen625!users.noreply.github.com
 	NCR Corporation until 2021-05-01
 	Sonatype Inc. from 2021-05-01


### PR DESCRIPTION
Update affiliation for raykrueger from Amazon to Spectro Cloud, effective October 2025.