### PR TITLE
Update NVIDIA developer affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -12194,10 +12194,11 @@ FilipSwiatczak: FilipSwiatczak!users.noreply.github.com, filip.swiatczak!gmail.c
 	Independent until 2017-07-01
 	Delio from 2017-07-01 until 2018-09-01
 	AJ Bell from 2018-09-01
-FillZpp: FillZpp!users.noreply.github.com
+FillZpp: fillzpp.pub!gmail.com, FillZpp!users.noreply.github.com
 	International Business Machines Corporation until 2014-06-01
 	Asiainfo Technologies (China) Inc. from 2014-06-01 until 2014-12-01
-	Alibaba Group from 2014-12-01
+	Alibaba Group from 2014-12-01 until 2025-04-07
+	NVIDIA Corporation from 2025-04-07
 FinVamp1: finbarr!microsoft.com
 	Microsoft Corporation
 Fine0830: fanxue0830!gmail.com

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -11598,7 +11598,7 @@ EthanHsieh: ethan.hsieh!canonical.com
 	Canonical Ltd.
 EthraZa: EthraZa!users.noreply.github.com, ethraza!gmail.com
 	GHSix
-Ethyling: Ethyling!users.noreply.github.com, jjacobelli!nvidia.com
+Ethyling: Ethyling!users.noreply.github.com, jjacobelli!nvidia.com, jjacobelli!users.noreply.github.com, jordanjacobelli04!gmail.com
 	NVIDIA Corporation
 Etienne-Carriere: etienne-carriere!users.noreply.github.com, etienne.a.carriere!socgen.com, etienne.carriere!gmail.com
 	Ministère des finances until 2015-12-01

--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -5,6 +5,8 @@
 # Note that email addresses below are "best effort" and are out-of-date
 # or inaccurate in many cases. Please do not rely on this email information
 # without verification.
+xdu31: jaydu!nvidia.com, xdu31!users.noreply.github.com
+	NVIDIA Corporation from 2025-12-01
 xiejunan: xiejunan!huawei.com, xiejunan!users.noreply.github.com
 	Huawei Technologies Co. Ltd
 xiekeyang: keyang.xie!gmail.com, xiekeyang!huawei.com, xiekeyang!users.noreply.github.com
@@ -5946,7 +5948,8 @@ zvlb: zvlb!users.noreply.github.com
 	СБЕР from 2021-06-01 until 2022-04-01
 	Obelis Limited from 2022-04-01
 zvonkok: zkosic!redhat.com, zvonkok!users.noreply.github.com
-	Red Hat Inc.
+	Red Hat Inc. until 2021-10-04
+	NVIDIA Corporation from 2021-10-04
 zw0610: zw0610!users.noreply.github.com
 	Independent until 2016-02-01
 	Wolfram Research from 2016-02-01 until 2018-03-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -13710,7 +13710,9 @@ a-know: a-know!users.noreply.github.com, a.know.3373!gmail.com, a.know.dev!gmail
 a-mccarthy: a-mccarthy!users.noreply.github.com, amccarthy!apprenda.com, amccarthy!heptio.com, mabigail!vmware.com
 	Apprenda Inc. until 2018-05-01
 	Heptio Inc. from 2018-05-01 until 2019-12-16
-	VMware Inc. from 2019-12-16
+	VMware Inc. from 2019-12-16 until 2023-11-22
+	Broadcom from 2023-11-22 until 2024-12-11
+	NVIDIA Corporation from 2024-12-11
 a-monteiro: a-monteiro!users.noreply.github.com
 	Tsolnetworks until 2022-02-01
 	Dune from 2022-02-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -12318,7 +12318,7 @@ bep: bep!users.noreply.github.com, bjorn.erik.pedersen!gmail.com, gomes.tisystem
 bephinix: bephinix!users.noreply.github.com
 	Independent until 2020-04-01
 	Fraunhofer FKIE from 2020-04-01
-berendt: berendt!b1-systems.de, berendt!betacloud-solutions.de, berendt!users.noreply.github.com, christian!berendt.io, fillzpp.pub!gmail.com, junkmail!donaldpistole.com
+berendt: berendt!b1-systems.de, berendt!betacloud-solutions.de, berendt!users.noreply.github.com, christian!berendt.io, junkmail!donaldpistole.com
 	B1 Systems GmbH
 berenss: berenss!users.noreply.github.com, sberens!redhat.com
 	Red Hat Inc.
@@ -20449,6 +20449,8 @@ cdennig: dechrist!microsoft.com
 	ITML until 2015-12-01
 	Smart from 2015-12-01 until 2016-12-01
 	Microsoft Corporation from 2016-12-01
+cdesiniotis: cdesiniotis!users.noreply.github.com, chris.desiniotis!gmail.com
+	NVIDIA Corporation from 2021-07-19
 cdevienne: cdevienne!users.noreply.github.com, christophe!cdevienne.info
 	Orus
 cdickmann: cdickmann!users.noreply.github.com

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -5764,6 +5764,8 @@ arpitjindal97: arpitjindal97!gmail.com, arpitjindal97!users.noreply.github.com
 	gvcsystems from 2016-05-01 until 2016-06-01
 	Independent from 2016-06-01 until 2018-08-01
 	SAP from 2018-08-01
+arpitsardhana: arpsingh!nvidia.com, arpitsardhana!users.noreply.github.com
+	NVIDIA Corporation from 2021-06-28
 arpitpandey0209: arpitpandey0209!users.noreply.github.com, f2013075!goa.bits-pilani.ac.in
 	Independent until 2020-05-01
 	Huegli from 2020-05-01 until 2020-11-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -22160,7 +22160,8 @@ fanweixiao: fanweixiao!gmail.com, fanweixiao!users.noreply.github.com
 	YoMo
 fanzhangio: fanz!vmware.com, fanzhangio!users.noreply.github.com
 	SAP until 2015-01-01
-	VMware Inc. from 2015-01-01
+	VMware Inc. from 2015-01-01 until 2020-09-08
+	NVIDIA Corporation from 2020-09-08
 fao89: fabricio!redhat.com, fao89!users.noreply.github.com
 	Independent until 2015-03-01
 	Baker Hughes from 2015-03-01 until 2016-03-01
@@ -23406,8 +23407,11 @@ fidelcoria-aa: fidelcoria-aa!users.noreply.github.com
 	tejas roofing until 2017-08-01
 	Independent from 2017-08-01 until 2018-06-01
 	American Airlines from 2018-06-01
-fidencio: fabiano!fidencio.org, fidencio!redhat.com, fidencio!users.noreply.github.com
-	Red Hat Inc.
+fidencio: fabiano!fidencio.org, fabiano.fidencio!intel.com, fidencio!northflank.com, fidencio!redhat.com, fidencio!users.noreply.github.com
+	Red Hat Inc. until 2021-12-01
+	Intel Corporation from 2021-12-01 until 2025-07-01
+	Northflank from 2025-07-01 until 2025-09-22
+	NVIDIA Corporation from 2025-09-22
 fiedukow: fiedukow!gmail.com, fiedukow!users.noreply.github.com
 	Opera Software ASA until 2016-02-01
 	Teradata from 2016-02-01 until 2017-09-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -2029,7 +2029,8 @@ g-gaston: g-gaston!users.noreply.github.com
 	Independent until 2016-10-01
 	Grainger from 2016-10-01 until 2018-11-01
 	Fooda from 2018-11-01 until 2021-03-01
-	AWS from 2021-03-01
+	AWS from 2021-03-01 until 2025-12-01
+	NVIDIA Corporation from 2025-12-01
 g-io: g-io!users.noreply.github.com
 	MeteoGroup until 2021-01-01
 	Volkswagen from 2021-01-01
@@ -8179,7 +8180,8 @@ gyuho: gyuho!users.noreply.github.com, gyuhox!gmail.com, leegyuho!amazon.com
 	CoreOS Inc. from 2015-12-01 until 2018-08-01
 	Amazon from 2018-08-01 until 2021-10-01
 	Ava Labs from 2021-10-01 until 2023-07-01
-	TBA from 2023-07-01
+	TBA from 2023-07-01 until 2025-04-07
+	NVIDIA Corporation from 2025-04-07
 gyulaweber: gyula.weber.in!gmail.com, gyula_weber!fastmail.com, gyulaweber!users.noreply.github.com
 	EPAM Systems Inc
 gyunnkim: gyunnkim!users.noreply.github.com

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -22001,10 +22001,11 @@ jgbernalp: jgbernalp!users.noreply.github.com
 	Red Hat Inc. from 2022-01-01
 jgeewax: jgeewax!users.noreply.github.com, jj!geewax.org
 	Google LLC
-jgehrcke: jgehrcke!googlemail.com, jgehrcke!users.noreply.github.com
+jgehrcke: jgehrcke!googlemail.com, jgehrcke!nvidia.com, jgehrcke!users.noreply.github.com
 	Independent until 2015-10-01
 	Mesosphere from 2015-10-01 until 2019-10-01
-	TBD - TV from 2019-10-01
+	TBD - TV from 2019-10-01 until 2025-01-27
+	NVIDIA Corporation from 2025-01-27
 jgelens: jeffrey!gelens.org, jgelens!users.noreply.github.com
 	Noppo
 jgeliex: jonathanx.gelie!intel.com

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -6047,7 +6047,8 @@ jyotibhanot: jyoti.bhanot30!gmail.com, jyotibhanot!users.noreply.github.com
 jyotimahapatra: jyotimahapatra!users.noreply.github.com
 	Microsoft Corporation until 2019-03-29
 	Lyft Inc. from 2019-03-29 until 2020-12-18
-	Amazon from 2020-12-18
+	Amazon from 2020-12-18 until 2025-11-03
+	NVIDIA Corporation from 2025-11-03
 jyotipatel: jyotipatel!users.noreply.github.com
 	Independent until 2016-05-01
 	FreeCharge from 2016-05-01 until 2016-07-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -13034,6 +13034,9 @@ ndjido: ndjido!gmail.com
 	AXA Financial Inc. from 2015-12-01 until 2016-09-01
 	Davidson Consulting UAE from 2016-09-01 until 2020-03-01
 	DScale.io from 2020-03-01
+ndipebot: endipagbor!apple.com, ndipebot!gmail.com, ndipebot!users.noreply.github.com
+	Apple Inc. until 2025-07-07
+	NVIDIA Corporation from 2025-07-07
 ndobryanskyy: 34073648+ndobryanskyy!users.noreply.github.com, ndobryanskyy!gmail.com
 	Lohika Systems Inc.
 ndotb: neilebailey!gmail.com

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -11402,7 +11402,8 @@ mxpv: makpav!amazon.com, mxpv!users.noreply.github.com, pavlenko.maksym!gmail.co
 	Siftheme until 2016-12-01
 	Independent from 2016-12-01 until 2018-09-01
 	Amazon from 2018-09-01 until 2020-04-01
-	Apple Inc. from 2020-04-01
+	Apple Inc. from 2020-04-01 until 2024-12-30
+	NVIDIA Corporation from 2024-12-30
 mxsavchenko: mxsavchenko!users.noreply.github.com
 	ТК Череда until 2015-10-01
 	Latera LLC from 2015-10-01 until 2017-02-01
@@ -12612,7 +12613,8 @@ nathantsoi: nathan!vertile.com, nathantsoi!users.noreply.github.com
 nathanweatherly: nathanweatherly!users.noreply.github.com
 	Red Hat Inc.
 natherz97: nathan.herz97!gmail.com, natherz!amazon.com, natherz97!users.noreply.github.com
-	Amazon
+	Amazon until 2025-07-14
+	NVIDIA Corporation from 2025-07-14
 nathforge: email!nreynolds.co.uk, nathforge!users.noreply.github.com
 	Proxama until 2017-01-01
 	KCOM from 2017-01-01 until 2019-10-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -5074,6 +5074,8 @@ micnncim: micnncim!gmail.com, micnncim!users.noreply.github.com
 	Independent
 micpez: michele.pezzutti!hcl.com
 	HCL Technologies Ltd.
+mikecook: micook!nvidia.com, mikecook!users.noreply.github.com
+	NVIDIA Corporation from 2024-09-19
 microadam: adam.duncan!clock.co.uk, microadam!users.noreply.github.com
 	Clock
 microbuilder: dreadpirateshawn!gmail.com, kevin!ktownsend.com, microbuilder!users.noreply.github.com
@@ -8855,7 +8857,8 @@ mosesr76: mosesr!mellanox.com
 mosfet1kg: mosfet1kg!users.noreply.github.com
 	KAIST
 moshe010: moshe010!users.noreply.github.com, moshele!mellanox.com
-	Mellanox
+	Mellanox until 2020-04-27
+	NVIDIA Corporation from 2020-04-27
 mosheavni: mosheavni!users.noreply.github.com
 	IAF until 2014-10-01
 	Independent from 2014-10-01 until 2015-01-01

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -3846,7 +3846,8 @@ qbarrand: qbarrand!users.noreply.github.com, quentin!quba.fr
 	SNCF Réseau until 2016-08-01
 	CERN from 2016-08-01 until 2019-08-01
 	Swisscom from 2019-08-01 until 2021-09-01
-	Red Hat Inc. from 2021-09-01
+	Red Hat Inc. from 2021-09-01 until 2024-08-05
+	NVIDIA Corporation from 2024-08-05
 qbl: codobanclaudiu!gmail.com, farabi.iqbal!gmail.com, hello.rusinov!gmail.com, qbl!users.noreply.github.com
 	PT.Stargle until 2015-12-01
 	Virkea Empresa Sistema from 2015-12-01 until 2017-12-01

--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -6470,6 +6470,8 @@ rayandas: rayandas!users.noreply.github.com
 	OneTrust from 2024-01-01
 rayashworth: ashworth!us.ibm.com
 	International Business Machines Corporation
+rayburgemeestre: rayb!nvidia.com, rayburgemeestre!users.noreply.github.com
+	NVIDIA Corporation from 2022-03-01
 raybejjani: ray!isovalent.com , raybejjani!users.noreply.github.com
 	Stripe Inc. until 2017-09-01
 	Isovalent from 2017-09-01 until 2020-05-01

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -7465,12 +7465,10 @@ tarilabs: tarilabs!users.noreply.github.com
 tarioch: patrick!ch.tario.org, patrick.ruckstuhl!fisglobal.com, tarioch!users.noreply.github.com
 	SunGard Financial until 2015-12-01
 	FIS from 2015-12-01
-tariq1890: taibrahi!microsoft.com, tariq.ibrahim!microsoft.com, tariq181290!gmail.com, tariq1890!users.noreply.github.com
-	comScore Inc. until 2014-06-01
-	CircleBack from 2014-06-01 until 2017-10-01
-	Capital One from 2017-10-01 until 2019-06-01
-	Microsoft Corporation from 2019-06-01 until 2022-06-27
-	NVIDIA Corporation from 2022-06-27
+tariq1890: tariq181290!gmail.com, tariq1890!users.noreply.github.com, tibrahim!nvidia.com
+	Microsoft Corporation from 2018-05-01 until 2019-04-01
+	Salesforce.com Inc. from 2019-04-01 until 2022-07-01
+	NVIDIA Corporation from 2022-07-01
 tarlano: tarlano!users.noreply.github.com
 	Exablox until 2016-01-01
 	Apple Inc. from 2016-01-01

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -7468,7 +7468,9 @@ tarioch: patrick!ch.tario.org, patrick.ruckstuhl!fisglobal.com, tarioch!users.no
 tariq1890: taibrahi!microsoft.com, tariq.ibrahim!microsoft.com, tariq181290!gmail.com, tariq1890!users.noreply.github.com
 	comScore Inc. until 2014-06-01
 	CircleBack from 2014-06-01 until 2017-10-01
-	Capital One from 2017-10-01
+	Capital One from 2017-10-01 until 2019-06-01
+	Microsoft Corporation from 2019-06-01 until 2022-06-27
+	NVIDIA Corporation from 2022-06-27
 tarlano: tarlano!users.noreply.github.com
 	Exablox until 2016-01-01
 	Apple Inc. from 2016-01-01

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -19818,6 +19818,8 @@ vschettino-asimov: vschettino-asimov!users.noreply.github.com
 	Passei Direto from 2020-09-01 until 2021-10-01
 	Passei Direto from 2021-10-01 until 2021-11-01
 	Asimov from 2021-11-01
+varunrsekar: vsekar!nvidia.com, varunrsekar!users.noreply.github.com
+	NVIDIA Corporation from 2022-06-06
 vsekhar: vivek!xmain.com, vsekhar!users.noreply.github.com
 	Google LLC
 vshankar: vshankar!redhat.com


### PR DESCRIPTION
## Summary

- Update 10 developers with current NVIDIA affiliations based on cross-referencing
  kubernetes and NVIDIA GitHub org membership.
  (@a-mccarthy, @gyuho, @jyotimahapatra, @mxpv, @natherz97, @qbarrand, @tariq1890,
  @zvonkok, @FillZpp, @g-gaston)
- Add 3 new developer entries (@cdesiniotis, @xdu31, @ndipebot)
- Add @jjacobelli GitHub handle aliases to existing Ethyling entry
- Fix fillzpp.pub email mis-attribution from berendt to @FillZpp
