### PR TITLE
Fix slaskawi affiliation: replace incorrect monday.com with MongoDB and Defense Unicorns

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -23378,9 +23378,10 @@ slashr: slashr!users.noreply.github.com
 	Independent from 2017-09-01 until 2018-09-01
 	Checkout Charlie from 2018-09-01 until 2020-12-01
 	understand.ai from 2020-12-01
-slaskawi: slaskawi!redhat.com, slaskawi!users.noreply.github.com
+slaskawi: sebastian.laskawiec!gmail.com, sebastian.laskawiec!redhat.com, slaskawi!redhat.com, slaskawi!users.noreply.github.com, sebastian.laskawiec!mongodb.com, sebastian.laskawiec!defenseunicorns.com
 	Red Hat Inc. until 2022-06-01
-	monday.com Limited from 2022-06-01
+	MongoDB Inc from 2022-06-01 until 2025-01-01
+	Defense Unicorns from 2025-01-01
 slater-ben: ben.slater!instaclustr.com
 	Accenture Global Solutions Limited until 2015-02-01
 	NetApp from 2015-02-01 until 2025-04-01


### PR DESCRIPTION
Replace incorrect monday.com Limited affiliation with correct employment history:
- Red Hat Inc. until 2022-06-01 (unchanged)
- MongoDB Inc from 2022-06-01 until 2025-01-01
- Defense Unicorns from 2025-01-01 (current)

Also added missing email addresses to the entry.