### PR TITLE
Add Keymate affiliations for Alnyli07, erenkan, and muhammedogz

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -2918,6 +2918,8 @@ AlonMiz: AlonMiz!users.noreply.github.com
 	Logshero Ltd. from 2016-12-01
 AlonaKaplan: alkaplan!redhat.com
 	Red Hat Inc.
+Alnyli07: ali!keymate.io, altgrlpinar!gmail.com
+	Keymate from 2025-01-01
 Aloren: Aloren!users.noreply.github.com, asmirnova!playtika.com, zminyty!gmail.com
 	Playtika
 Alos: Alos!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -19904,6 +19904,8 @@ erezzarum: erezzarum!users.noreply.github.com
 	PurePeak from 2017-02-01 until 2022-03-01
 	Independent from 2022-03-01 until 2022-07-01
 	AWS from 2022-07-01
+erenkan: eren!keymate.io, erenkn!gmail.com
+	Keymate from 2025-01-01
 erfan-mehraban: erfan.mehraban!gmail.com
 	Independent until 2016-01-01
 	Saaland from 2016-01-01 until 2018-04-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -10895,6 +10895,8 @@ muhammadn: muhammad!taqisystems.com
 	BUTLER from 2019-11-01 until 2020-04-01
 	Awesell from 2020-04-01 until 2021-03-01
 	Setel from 2021-03-01
+muhammedogz: muhammed!keymate.io, 54470681+muhammedogz!users.noreply.github.com, muhammed0748!outlook.com
+	Keymate from 2025-07-01
 muhendees: muhendees!gmail.com
 	Smarty until 2021-01-01
 	Perceptyx from 2021-01-01 until 2022-10-01


### PR DESCRIPTION
Added company affiliations for three Keymate team members:
- Alnyli07 (ali@keymate.io) - joined 2025-01-01
- erenkan (eren@keymate.io) - joined 2025-01-01
- muhammedogz (muhammed@keymate.io) - joined 2025-07-01

All entries include historical email addresses for proper attribution of contributions to CNCF projects including Keycloak.