### PR TITLE
Add Keymate affiliations for hakdogan and mehmetenesturan

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -8666,6 +8666,8 @@ hakanaltindag: hakanaltindag!users.noreply.github.com
 	Huawei Technologies Co. Ltd from 2023-12-01 until 2025-03-01
 	ICRYPEX from 2025-03-01 until 2025-10-01
 	Private from 2025-10-01
+hakdogan: huseyin!keymate.io, hakdogan75!gmail.com
+	Keymate from 2025-10-14
 hakanmemisoglu: hakan!kasten.io, hakanmemisoglu!users.noreply.github.com
 	Independent until 2017-05-01
 	Microsoft Corporation from 2017-05-01 until 2017-08-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -3300,6 +3300,8 @@ mehemken: mehemken!users.noreply.github.com
 	iHerb LLC from 2018-07-01 until 2019-08-01
 	New York Times from 2019-08-01 until 2021-11-01
 	VTS from 2021-11-01
+mehmetenesturan: enes!keymate.io, turanenesmehmet!gmail.com
+	Keymate from 2025-07-07
 mehmetuken: mehmetuken!users.noreply.github.com
 	Fikrinevi until 2015-12-01
 	Independent from 2015-12-01 until 2021-09-01


### PR DESCRIPTION
Added company affiliations for two Keymate team members:
- hakdogan (huseyin@keymate.io) - joined 2025-10-14
- mehmetenesturan (enes@keymate.io) - joined 2025-07-07

Both team members have contributed to CNCF projects through issue reporting and community engagement.

All entries include historical email addresses for proper attribution of contributions to CNCF projects including Keycloak.