### PR TITLE
Added company affiliations for seven F5 team members

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -2384,6 +2384,8 @@ AlbertasG: AlbertasG!users.noreply.github.com, grinkevicius.albertas!gmail.com
 	Humn from 2021-12-01
 Albertchamberlain: Albertchamberlain!users.noreply.github.com
 	NULL
+albertlockett: albertlockett!users.noreply.github.com, a.lockett!f5.com
+	F5 Inc. from 2025-05-01
 AlbertoPeon: AlbertoPeon!users.noreply.github.com, alberto.rodriguez.peon!cern.ch
 	CERN
 Alceatraz: Alceatraz!users.noreply.github.com, alceatraz!blacktech.studio
@@ -6729,6 +6731,8 @@ C-Society: 32087475+c-society!users.noreply.github.com, C-Society!users.noreply.
 C123R: C123R!users.noreply.github.com, cizer.ciz!gmail.com
 	Infosys Limited until 2017-09-01
 	ZEISS from 2017-09-01
+c1ly: c1ly!users.noreply.github.com, c.ly@f5.com
+	F5 Inc. from 2025-05-01
 C24IO: c!24.io
 	Cisco Systems Inc. until 2014-12-01
 	Infoblox Inc. from 2014-12-01 until 2016-06-01
@@ -8022,6 +8026,8 @@ Clemmy: Clemmy!users.noreply.github.com, clement.hoang24!gmail.com
 CleverChuk: CleverChuk!users.noreply.github.com
 	Independent until 2022-06-01
 	SolarWinds Worldwide LLC from 2022-06-01
+clhain: clhain!users.noreply.github.com, c.hain@f5.com
+	F5 Inc. from 2025-05-01
 Cliftonz: Cliftonz!users.noreply.github.com
 	Independent until 2020-02-01
 	Alezion from 2020-02-01 until 2020-12-01
@@ -9365,6 +9371,8 @@ DavidCADanneels: daviddafke!msn.com
 	Fidelity National Information Services Inc. from 2015-03-01
 DavidCPhillips: dcphillips!google.com
 	Google LLC
+daviddahl: daviddahl!users.noreply.github.com, d.dahl@f5.com
+	F5 Inc. from 2025-05-01
 DavidGamba: DavidGamba!users.noreply.github.com
 	PureWeb until 2018-02-01
 	Pason from 2018-02-01 until 2021-09-01
@@ -16171,6 +16179,8 @@ JakeColor: JakeColor!users.noreply.github.com
 	M Science from 2018-08-01 until 2020-09-01
 	Entrepreneur First from 2020-09-01 until 2021-01-01
 	Riskfuel from 2021-01-01
+JakeDern: JakeDern!users.noreply.github.com, j.dern@f5.com
+	F5 Inc. from 2026-01-01
 JakeMoh: JakeMoh!users.noreply.github.com
 	Independent until 2020-01-01
 	SAP from 2020-01-01
@@ -23504,6 +23514,8 @@ Mryashbhardwaj: Mryashbhardwaj!users.noreply.github.com, yashabsolution!gmail.co
 	Abyeti Technologies from 2018-02-01 until 2019-04-01
 	VWO from 2019-04-01 until 2022-03-01
 	GOJEK from 2022-03-01
+msalib: msalib!users.noreply.github.com, m.salib@f5.com
+	F5 Inc. from 2025-07-01 until 2025-08-31
 Mstoegerer: markus.stoegerer!gmail.com, mstoegerer!users.noreply.github.com
 	Ranorex GmbH
 Mstrodl: Mstrodl!users.noreply.github.com

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -18448,9 +18448,9 @@ lqdev: lqdev!outlook.com, lqdev!users.noreply.github.com
 	Bank of New York Mellon until 2018-03-01
 	Accenture Global Solutions Limited from 2018-03-01 until 2019-01-01
 	Microsoft Corporation from 2019-01-01
-lquerel: lquerel!users.noreply.github.com
+lquerel: lquerel!users.noreply.github.com, l.querel!f5.com, laurent.querel!gmail.com
 	CloudWeaver until 2015-01-01
-	Jabulani Sp. z o. o from 2015-01-01
+	F5 Inc. from 2015-01-01
 lrakai: lrakai!users.noreply.github.com
 	Obsidian Solutions until 2015-09-01
 	The PYXIS innovation from 2015-09-01 until 2017-02-01


### PR DESCRIPTION
Added company affiliations for seven F5 team members:
- albertlockett
- c1ly
- clhain
- daviddahl
- JakeDern
- lquerel
- msalib

All entries include historical email addresses for proper attribution of contributions to CNCF projects including OpenTelemetry otel-arrow and weaver projects.