### PR TITLE
update crandles affiliation: add warner bros. discovery

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -3237,8 +3237,9 @@ cramseyio: cramseyio!users.noreply.github.com
 	ConocoPhillips until 2016-10-01
 	Walt Disney Animation Studios from 2016-10-01 until 2017-04-01
 	ConocoPhillips from 2017-04-01
-crandles: christopher_randles!cable.comcast.com, crandles!users.noreply.github.com, randles.chris!gmail.com
-	Comcast Cable Communications LLC (Xfinity)
+crandles: christopher_randles!cable.comcast.com, crandles!users.noreply.github.com, randles.chris!gmail.com, chris.randles!wbd.com
+	Comcast Cable Communications LLC (Xfinity) until 2021-07-01
+	Warner Bros. Discovery from 2021-07-01
 crandmck: crandmck!users.noreply.github.com, crandmck!yahoo.com
 	StrongLoop until 2015-11-01
 	International Business Machines Corporation from 2015-11-01 until 2017-11-01


### PR DESCRIPTION
Updating my own entry: closing Comcast at 2021-07-01 and adding Warner Bros. Discovery from 2021-07-01. Also adding `chris.randles@wbd.com` to the alias list.