### PR TITLE
Add Keymate affiliations for HalilOzkan and BurakYildrm

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -6663,6 +6663,8 @@ BumpeiShimada: BumpeiShimada!users.noreply.github.com
 BurakCetin3129: BurakCetin3129!users.noreply.github.com
 	Independent until 2022-10-01
 	Cardlay from 2022-10-01
+BurakYildrm: burak!keymate.io
+	Keymate from 2026-01-10
 Burhan-Q: Burhan-Q!users.noreply.github.com
 	Hoishik until 2018-05-01
 	Corning from 2018-05-01 until 2020-01-01
@@ -14091,6 +14093,8 @@ HalfBottleOfMind: andromalak222!gmail.com
 	ПАО Электроприбор from 2015-08-01 until 2018-11-01
 	ПАО МИЭА from 2018-11-01 until 2022-07-01
 	Россети Цифра from 2022-07-01
+HalilOzkan: halil!keymate.io
+	Keymate from 2026-01-01
 Halytskyi: Halytskyi!users.noreply.github.com
 	SMTP until 2015-10-01
 	TubeMogul from 2015-10-01 until 2017-04-01


### PR DESCRIPTION
Added company affiliations for two Keymate team members:
- HalilOzkan (halil@keymate.io) - joined 2026-01-01
- BurakYildrm (burak@keymate.io) - joined 2026-01-10

Both team members contribute to CNCF projects including Keycloak.