### PR TITLE
docs: update affiliation for tuunit

### DIFF
--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -15184,7 +15184,8 @@ tuukkamustonen: tuukkamustonen!users.noreply.github.com
 tuunit: jan!larwig.com, tuunit!users.noreply.github.com
 	Independent until 2019-06-01
 	Capgemini from 2019-06-01 until 2024-09-01
-	IONOS from 2024-09-01
+	IONOS from 2024-09-01 until 2026-04-01
+	STACKIT from 2026-04-01
 tuvovan: tuvovan!users.noreply.github.com, vovantu.hust!gmail.com
 	True
 tux-o-matic: tux-o-matic!users.noreply.github.com


### PR DESCRIPTION
Should I update github_users.json and the email-map files as well? This isn't clear from the README.

It states:

> Only the Developers affiliations list [dev1](https://github.com/cncf/gitdm/blob/master/developers_affiliations1.txt), [dev2](https://github.com/cncf/gitdm/blob/master/developers_affiliations2.txt), [dev3](https://github.com/cncf/gitdm/blob/master/developers_affiliations3.txt), [dev4](https://github.com/cncf/gitdm/blob/master/developers_affiliations4.txt), [dev5](https://github.com/cncf/gitdm/blob/master/developers_affiliations5.txt), ... should be edited manually.

but a paragraph later it also states:

> Other files used for affiliations are the [email map file](https://github.com/cncf/gitdm/blob/master/src/cncf-config/email-map) and [github users](https://github.com/cncf/gitdm/blob/master/src/github_users.json) file.