### PR TITLE
Fix HalilOzkan Keymate join date to 2025-01-01

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -14109,8 +14109,8 @@ HalfBottleOfMind: andromalak222!gmail.com
 	ПАО МИЭА from 2018-11-01 until 2022-07-01
 	Россети Цифра from 2022-07-01
 HalilOzkan: halil!keymate.io
-	Independent until 2026-01-10
-	Keymate from 2026-01-10
+	Independent until 2025-01-01
+	Keymate from 2025-01-01
 Halytskyi: Halytskyi!users.noreply.github.com
 	SMTP until 2015-10-01
 	TubeMogul from 2015-10-01 until 2017-04-01


### PR DESCRIPTION
Correct the join date for HalilOzkan at Keymate. The previously submitted date was incorrect; the actual join date is 2025-01-01.