### PR TITLE
Add karthi-palanisamy affiliation

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -7763,6 +7763,8 @@ karthequian: karthequian!users.noreply.github.com, karthik.gaekwad!gmail.com
 	Signal from 2014-07-01 until 2014-11-01
 	StackEngine (now owned by Oracle) from 2014-11-01 until 2016-02-01
 	Red Hat Inc. from 2016-02-01
+karthi-palanisamy: karthi-palanisamy!users.noreply.github.com, karthipalanisamy.dev!gmail.com, karthipalanisamy14!gmail.com, infokarthi14!gmail.com
+	Independent
 karthicgit: karthicgit!users.noreply.github.com
 	Mphasis Limited until 2014-11-01
 	Caterpillar India Private Limited from 2014-11-01 until 2016-11-01


### PR DESCRIPTION
Adding my own developer entry with Independent affiliation. Includes my GitHub noreply address and personal email aliases for proper attribution of contributions to CNCF projects (Flux, Helm, Kubernetes website).