### PR TITLE
Add gjbravi affiliation (Red Hat Inc., Wellhub)

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -5440,6 +5440,11 @@ gj199575: 409237405!qq.com, Gj199575!users.noreply.github.com, guojian67!huawei.
 gjacquet: gjacquet!users.noreply.github.com
 	AppDirect until 2018-04-01
 	Upgrade Inc. from 2018-04-01
+gjbravi: gbravi!redhat.com, gjbravi!users.noreply.github.com, guilherme.bravi!wellhub.com
+	Red Hat Inc. until 2022-02-01
+	Independent from 2022-02-01 until 2022-10-01
+	Red Hat Inc. from 2022-10-01 until 2024-04-01
+	Wellhub from 2024-04-01
 gjc13: gjc!google.com, guoamtcmp!gmail.com
 	Google LLC
 gjcairo: gjcairo!users.noreply.github.com


### PR DESCRIPTION
Adding my own affiliation to `developers_affiliations5.txt`.

- GitHub: gjbravi
- Emails: `gbravi@redhat.com`, `gjbravi@users.noreply.github.com`, `guilherme.bravi@wellhub.com`
- Affiliations:
  - Red Hat Inc. until 2022-02-01
  - Independent from 2022-02-01 until 2022-10-01
  - Red Hat Inc. from 2022-10-01 until 2024-04-01
  - Wellhub from 2024-04-01

Entry inserted alphabetically between `gjacquet` and `gjc13`.