### PR TITLE
update gauravgahlot affiliation

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -3476,7 +3476,7 @@ gauravbhandare: gauravbhandare!users.noreply.github.com
 gauravgahlot: gauravgahlot!users.noreply.github.com, ggahlot!infracloud.io
 	Independent until 2015-08-01
 	Cybage Software from 2015-08-01 until 2019-08-01
-	Infracloud Technologies INC from 2019-08-01 until 2021-08-01
+	InfraCloud Technologies from 2019-08-01 until 2021-08-01
 	Independent from 2021-08-01
 gauravkm: gauravkm!gmail.com, gauravkm!users.noreply.github.com
 	Directi until 2015-06-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -3476,7 +3476,8 @@ gauravbhandare: gauravbhandare!users.noreply.github.com
 gauravgahlot: gauravgahlot!users.noreply.github.com, ggahlot!infracloud.io
 	Independent until 2015-08-01
 	Cybage Software from 2015-08-01 until 2019-08-01
-	Infracloud Technologies INC from 2019-08-01
+	Infracloud Technologies INC from 2019-08-01 until 2021-08-01
+	Independent from 2021-08-01
 gauravkm: gauravkm!gmail.com, gauravkm!users.noreply.github.com
 	Directi until 2015-06-01
 	Independent from 2015-06-01 until 2015-10-01


### PR DESCRIPTION
The PR:

- closes an open-ended InfraCloud range (left Aug 2021)
- marks commits since as `Independent`