### PR TITLE
Add mesutoezdil affiliation to Adfinis GmbH

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -4776,6 +4776,8 @@ mestery: kmestery!cisco.com, mestery!mestery.com, mestery!users.noreply.github.c
 	Cisco Systems Inc. from 2018-04-01
 mesutcelik: mesut!hazelcast.com, mesutcelik!users.noreply.github.com
 	Hazelcast Inc.
+mesutoezdil: mesudozdil!gmail.com
+	Adfinis GmbH
 metachris: chris!linuxuser.at, darby4738!gmail.com, elzioj.s!gmail.com, jakiejia!163.com, metachris!users.noreply.github.com
 	Bits Working
 metacosm: metacosm!users.noreply.github.com


### PR DESCRIPTION
Add GitHub login mesutoezdil with affiliation to Adfinis GmbH.

Email: mesudozdil@gmail.com
Company: Adfinis GmbH
Location: Germany