### PR TITLE
Add mgonzalezo affiliation with Red Hat

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -5544,6 +5544,8 @@ mgoddard: mgoddard!users.noreply.github.com
 mgoin: mgoin!redhat.com
 	Independent until 2019-08-01
 	Red Hat Inc. from 2019-08-01
+mgonzalezo: mantonio!sandiego.edu, margonza!redhat.com, mgonzalezo!users.noreply.github.com
+	Red Hat
 mgol: m.goleb!gmail.com, mgol!users.noreply.github.com
 	Independent until 2016-06-01
 	YouGov from 2016-06-01 until 2018-07-01


### PR DESCRIPTION
Add developer affiliation for GitHub user mgonzalezo (Marco Gonzalez)
with Red Hat.

Emails mapped:
- mantonio@sandiego.edu (used on past CNCF project commits)
- margonza@redhat.com (current Red Hat email)
- mgonzalezo@users.noreply.github.com (GitHub noreply)

This ensures DevStats correctly attributes contributions to
CNCF projects (e.g., kserve/website#691) under Red Hat.