### PR TITLE
Add timr-dev:Microsoft affiliation

### DIFF
--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -13203,6 +13203,8 @@ timperrett: timothy!getintheloop.eu, timperrett!users.noreply.github.com
 	Intel Corporation until 2014-02-01
 	Verizon from 2014-02-01 until 2017-12-01
 	Lyft Inc. from 2017-12-01
+timr-dev: tim.ren!microsoft.com
+	Microsoft Corporation from 2026-06-15
 timrchavez: tchavez!bluebox.net, tchavez!us.ibm.com
 	DigitalOcean
 timruffles: timruffles!gmail.com, timruffles!googlemail.com, timruffles!users.noreply.github.com


### PR DESCRIPTION
Enter my new affiliation, effective 2026-06-15.

Adds `timr-dev` (tim.ren@microsoft.com) with affiliation **Microsoft Corporation** from 2026-06-15, inserted in sorted order in `developers_affiliations9.txt`.