### PR TITLE
Add Lyndon-Li affiliation with VMware

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -21001,6 +21001,9 @@ Lykathia: Lykathia!users.noreply.github.com, lowry.e!gmail.com
 	NTT DATA until 2015-05-01
 	PitchPlay from 2015-05-01 until 2017-04-01
 	BeyondTrust from 2017-04-01
+Lyndon-Li: yonghui.li!broadcom.com, lyonghui!vmware.com, lyndon-li!hotmail.com, 98304688+Lyndon-Li!users.noreply.github.com
+	Independent until 2022-02-07
+	VMware Inc. from 2022-02-07
 Lynskylate: Lynskylate!users.noreply.github.com
 	eBay
 Lynton-Zhang: Lynton-Zhang!users.noreply.github.com


### PR DESCRIPTION
Add developer affiliation for GitHub user Lyndon-Li with VMware. Inserted in sorted order in developers_affiliations1.txt