### PR TITLE
Updated `ppatierno` affiliation with IBM

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -3227,7 +3227,8 @@ pparth: bhush94!gmail.com, pparth!cloud.upwork.com, pparth!users.noreply.github.
 ppatierno: ppatierno!live.com, ppatierno!users.noreply.github.com
 	Ditron until 2015-04-01
 	Leonardo Ricerche from 2015-04-01 until 2016-02-01
-	Red Hat Inc. from 2016-02-01
+	Red Hat Inc. from 2016-02-01 until 2025-07-01
+	IBM from 2025-07-01
 ppbits: ppbits!users.noreply.github.com, ppengdev!gmail.com
 	Microsoft Corporation
 ppcololo: 35843703+ppcololo!users.noreply.github.com, ppcololo!users.noreply.github.com


### PR DESCRIPTION
This PR updates my affiliation from Red Hat to IBM.