### PR TITLE
Fix company name for stmcginnis

### DIFF
--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -6367,13 +6367,13 @@ stmaute: stmaute!users.noreply.github.com
 	Bosch from 2015-09-01 until 2015-11-01
 	Independent from 2015-11-01 until 2016-03-01
 	Bosch from 2016-03-01
-stmcginnis: sean!lambdal.com, sean.mcginnis!dell.com, sean.mcginnis!gmail.com, sean.mcginnis!huawei.com, sean_mcginnis!dell.com, smcginnis!vmware.com, stmcg!amazon.com, stmcginnis!users.noreply.github.com
+stmcginnis: sean!lambda.ai, sean!lambdal.com, sean.mcginnis!dell.com, sean.mcginnis!gmail.com, sean.mcginnis!huawei.com, sean_mcginnis!dell.com, smcginnis!vmware.com, stmcg!amazon.com, stmcginnis!users.noreply.github.com
 	Dell Technologies until 2017-04-07
 	Huawei Technologies Co. Ltd from 2017-04-07 until 2019-06-01
 	Dell Technologies from 2019-06-01 until 2020-09-17
 	VMware Inc. from 2020-09-17 until 2022-07-15
 	AWS from 2022-07-15 until 2023-11-27
-	Lambda Labs from 2023-11-27
+	Lambda from 2023-11-27
 stmordret: pierre-yves.mordret!st.com
 	STMicroelectronics International N.V.
 stmpy: stmpy!me.com, stmpy!users.noreply.github.com


### PR DESCRIPTION
Had added as Lambda Labs, but that is not the correct, official company name.