### PR TITLE
Add affiliation for AcidLeroy

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -1634,6 +1634,8 @@ AchimGrolimund: AchimGrolimund!users.noreply.github.com
 	Luisi & Diener until 2017-01-01
 	Angenstein from 2017-01-01 until 2019-11-01
 	Helvetia from 2019-11-01
+AcidLeroy: AcidLeroy!users.noreply.github.com, cody!codyeilar.com, cody.eilar!omniva.com
+	Omniva from 2024-05-20
 Ackar: Ackar!users.noreply.github.com
 	Mozilla Corporation until 2014-09-01
 	Independent from 2014-09-01 until 2015-02-01


### PR DESCRIPTION
Adds affiliation mapping for GitHub user `AcidLeroy` (Cody Eilar) to **Omniva**, effective from 2024-05-20.

Contributing to Cluster API (e.g. kubernetes-sigs/cluster-api#13433) and its providers; this ensures those contributions are attributed to Omniva in DevStats.

Edited `developers_affiliations1.txt` only (the hand-maintained list). Includes GitHub no-reply, historical commit email, and current work email.