### PR TITLE
Add affiliation for DoisLONG

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -8858,6 +8858,9 @@ DNJha: DNJha!users.noreply.github.com
 	Independent until 2016-09-01
 	A*STAR from 2016-09-01 until 2020-09-01
 	100 Percent from 2020-09-01
+DoisLONG: 15221580643!163.com
+	Independent until 2023-04-03
+	BlueDot from 2023-04-03
 DP19: DP19!users.noreply.github.com
 	Staples Inc. until 2016-03-01
 	Netsertive from 2016-03-01 until 2020-11-01


### PR DESCRIPTION
This PR adds the affiliation information for GitHub user `DoisLONG`.

Affiliation history:

- Independent until 2023-04-03
- BlueDot from 2023-04-03

The listed email address is used in my KubeEdge contributions.