### PR TITLE
Add affiliation for polarAli (Neor)

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -3319,6 +3319,8 @@ polachz: polachz!users.noreply.github.com
 	NXP Semiconductors Netherlands B.V. from 2022-11-01 until 2025-01-01
 	Independent from 2025-01-01 until 2025-03-01
 	Cisco Systems Inc. from 2025-03-01
+polarAli: ali.ghotbizadeh!gmail.com, ali.ghotbizdeh!neor.pro
+	Neor
 polarathene: polarathene!users.noreply.github.com
 	SkyCity until 2014-03-01
 	Independent from 2014-03-01 until 2014-08-01


### PR DESCRIPTION
Adds my affiliation to the developers affiliations list.

- **polarAli** → **Neor** (current)
- Emails: `ali.ghotbizadeh@gmail.com` (historical) and `ali.ghotbizdeh@neor.pro` (current)

This lets DevStats attribute my CNCF contributions (e.g. argoproj/argo-cd) to Neor.