### PR TITLE
Add affiliation for Dr-L-in

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -10622,6 +10622,9 @@ DpoBoceka: DpoBoceka!users.noreply.github.com, kymaxnn!mail.ru
 Dr-Emann: Dr-Emann!users.noreply.github.com, dremann!gmail.com
 	Unisys until 2021-06-01
 	Capital One from 2021-06-01
+Dr-L-in: 784010563bo!gmail.com
+	Independent until 2009-05-04
+	BlueDot from 2009-05-04
 Dr-N00B: Dr-N00B!users.noreply.github.com
 	Independent until 2016-05-01
 	Cognizant Technology Solutions from 2016-05-01 until 2019-08-01


### PR DESCRIPTION
This PR adds the affiliation information for GitHub user `Dr-L-in`.

Affiliation history:

- Independent until 2009-05-04
- BlueDot from 2009-05-04

The listed email address is used in my KubeEdge contributions.