### PR TITLE
Correct polarAli Neor email affiliation

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -3366,7 +3366,7 @@ polachz: polachz!users.noreply.github.com
 	NXP Semiconductors Netherlands B.V. from 2022-11-01 until 2025-01-01
 	Independent from 2025-01-01 until 2025-03-01
 	Cisco Systems Inc. from 2025-03-01
-polarAli: ali.ghotbizadeh!gmail.com, ali.ghotbizdeh!neor.pro
+polarAli: ali.ghotbizadeh!gmail.com, ali.ghotbizadeh!neor.pro
 	Neor
 polarathene: polarathene!users.noreply.github.com
 	SkyCity until 2014-03-01


### PR DESCRIPTION
Follow-up to #1184: corrects a typo in the Neor email I added for `polarAli`.

`ali.ghotbizdeh!neor.pro` -> `ali.ghotbizadeh!neor.pro` (with the missing "a"). This is the address my commits are actually authored with and that is verified on my GitHub account, so it is the one that needs the Neor affiliation. The gmail address is unchanged.