### PR TITLE
Add csmuell affiliation (Microsoft)

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -4706,6 +4706,8 @@ csmart: chris!distroguy.com
 	Rackspace from 2017-01-15
 csmehta: csmehta!users.noreply.github.com, nergal!nergal.se
 	Intel Corporation
+csmuell: chmuell!microsoft.com, 58946606+csmuell!users.noreply.github.com, csmuell!users.noreply.github.com, chris!csmueller.com
+	Microsoft
 csnitker: csnitker!users.noreply.github.com
 	GoDaddy Operating Company LLC
 csnktms: csnktms!users.noreply.github.com


### PR DESCRIPTION
Add developer affiliation for [csmuell](https://github.com/csmuell) — Microsoft.

Contributing to [kubernetes-sigs/azurelustre-csi-driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) (SIG Cloud Provider, provider-azure subproject), joining teammate [jeffbearer](https://github.com/jeffbearer) (#1053).

Emails cover current and historical commit authorship per the contributing guidance.