### PR TITLE
Update OllyGarden affiliations

### DIFF
--- a/company_developers9.txt
+++ b/company_developers9.txt
@@ -4295,9 +4295,12 @@ Ollang Media:
 	bariscankurtkaya: bariscankurtkaya!gmail.com from 2021-07-01
 OllyGarden:
 	jpkrohling: jpkrohling!users.noreply.github.com, juraci!kroehling.de, juraci.github!kroehling.de from 2025-01-01
-	kuklyy: jakubmiklasz9!gmail.com, kuklyy!users.noreply.github.com from 2025-07-01
+	kuklyy: jakubmiklasz9!gmail.com, kuklyy!users.noreply.github.com from 2025-07-01 until 2026-02-01
+	lanaymc: lanaymc!users.noreply.github.com from 2025-07-14
+	leandrocaracciolo: leandro!ollygarden.com, leandrocaracciolo!users.noreply.github.com from 2025-05-01
 	niwoerner: nicolas!ollygarden.com, nicolas.woerner!clario.com, nicolaswoerner1!gmail.com, niwoerner!users.noreply.github.com from 2025-09-01
 	perebaj: perebaj!gmail.com, perebaj!users.noreply.github.com from 2025-12-01
+	vesari: 36129782+vesari!users.noreply.github.com, arianna.vespri!yahoo.it, vesari!users.noreply.github.com from 2025-10-28
 	yuriolisa: yurimsa!gmail.com, yuriolisa!users.noreply.github.com from 2025-01-15 until 2026-02-01
 Olmait:
 	gothicfann: gothicfann!users.noreply.github.com from 2020-07-01 until 2020-11-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -14985,7 +14985,7 @@ kukacz: kukacz!users.noreply.github.com
 	ESET North America from 2022-11-01
 kuklyy: jakubmiklasz9!gmail.com, kuklyy!users.noreply.github.com
 	Independent until 2025-07-01
-	OllyGarden from 2025-07-01
+	OllyGarden from 2025-07-01 until 2026-02-01
 kulinskyvs: kulinskyvs!users.noreply.github.com
 	Belhard until 2014-09-01
 	Kyriba from 2014-09-01
@@ -16226,6 +16226,9 @@ lan-n-tran: lan-n-tran!users.noreply.github.com
 	Capital One from 2022-09-01
 lanandra: lanandra!users.noreply.github.com, luthfi.anandra!gmail.com
 	PT Nusantara Compnet Integrator
+lanaymc: lanaymc!users.noreply.github.com
+	Independent until 2025-07-14
+	OllyGarden from 2025-07-14
 lance: lance!users.noreply.github.com, lanceball!gmail.com, lball!redhat.com
 	Red Hat Inc.
 lancehudson: lance!lancehudson.com, lancehudson!users.noreply.github.com
@@ -17064,6 +17067,9 @@ leandrobortoli: leandrobortoli!users.noreply.github.com
 	Independent until 2017-03-01
 	DB1 from 2017-03-01 until 2020-04-01
 	PagSeguro PagBank from 2020-04-01
+leandrocaracciolo: leandro!ollygarden.com, leandrocaracciolo!users.noreply.github.com
+	Independent until 2025-05-01
+	OllyGarden from 2025-05-01
 leandrocr: leandro.repolho!theiconic.com.au, leandrocr!users.noreply.github.com, leandrorepolho!gmail.com
 	Fundação Vanzolini until 2015-10-15
 	Cabify from 2015-10-15 until 2016-06-15

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -20706,6 +20706,9 @@ vespian: vespian!users.noreply.github.com
 	Allegro.pl sp. z o.o. from 2015-03-01 until 2015-07-01
 	Independent from 2015-07-01 until 2015-10-01
 	D2iQ Inc. (f/k/a Mesosphere) from 2015-10-01
+vesari: 36129782+vesari!users.noreply.github.com, arianna.vespri!yahoo.it, vesari!users.noreply.github.com
+	Independent until 2025-10-28
+	OllyGarden from 2025-10-28
 veverkap: veverkap!users.noreply.github.com
 	ThreatSim until 2015-10-01
 	Wombat Security from 2015-10-01 until 2017-07-01

--- a/src/github_users.json
+++ b/src/github_users.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1c37da316f91419678b54ba9f63d690eeac3dd394fb55c09fe0c340e9de4e1c
-size 85997850
+oid sha256:f5645093597b8efbdd3c53893b0f1dd0b227e242d01b3d7921cd8bf4e6e2c1c8
+size 85999178


### PR DESCRIPTION
Updates affiliations for OllyGarden team members:

- Add @vesari — OllyGarden from 2025-10-28
- Add @leandrocaracciolo — OllyGarden from 2025-05-01
- Add @lanaymc — OllyGarden from 2025-07-14
- End @kuklyy's OllyGarden affiliation on 2026-02-01

Changes are applied consistently across `developers_affiliations*.txt`, `company_developers9.txt`, `src/cncf-config/email-map`, and `src/github_users.json`.

@vesari @leandrocaracciolo @lanaymc @kuklyy — please confirm these dates are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFCN8TE1tH2kXSqbJbB3HR