### PR TITLE
Update affiliation of ymotongpoo

### DIFF
--- a/company_developers5.txt
+++ b/company_developers5.txt
@@ -3297,7 +3297,6 @@ Google LLC:
 	yjbanov: yjbanov!google.com, yjbanov!users.noreply.github.com
 	yliaog: yliao!google.com, yliaog!users.noreply.github.com
 	ylil93: pekopeko!google.com
-	ymotongpoo: ymotongpoo!users.noreply.github.com
 	ynambiar: ynambiar!users.noreply.github.com from 2016-05-01 until 2017-08-01
 	yodahekinsew: yodahekinsew!users.noreply.github.com from 2019-06-01 until 2019-08-01, from 2022-08-01
 	yolo3301: cshou!google.com
@@ -3830,6 +3829,7 @@ Grafana Labs:
 	woodsaj: awoods!raintank.io, woodsaj!users.noreply.github.com
 	xaque208: xaque208!gmail.com, xaque208!users.noreply.github.com from 2021-05-01
 	ying-jeanne: ying-jeanne!users.noreply.github.com from 2020-12-01
+	ymotongpoo: ymotongpoo!users.noreply.github.com, ymotongpoo!gmail.com, yoshi.yamaguchi!grafana.com from 2026-04-07
 	yvrhdn: 7748404+yvrhdn!users.noreply.github.com, yvrhdn!users.noreply.github.com from 2021-04-01
 	ywwg: 888940+ywwg!users.noreply.github.com, owen.williams!grafana.com, owilliams!mixxx.org, ywwg!users.noreply.github.com from 2021-07-01
 	zalegrala: 88330524+zalegrala!users.noreply.github.com, zalegrala!users.noreply.github.com from 2021-07-01

--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -5772,8 +5772,10 @@ ymlbright: yml_bright!163.com
 	NetEase Inc
 ymmt2005: ymmt!cybozu.com, ymmt2005!gmail.com, ymmt2005!users.noreply.github.com
 	Cybozu
-ymotongpoo: ymotongpoo!users.noreply.github.com
-	Google LLC
+ymotongpoo: ymotongpoo!users.noreply.github.com, ymotongpoo!gmail.com, yoshi.yamaguchi!grafana.com
+	Google LLC until 2024-11-01
+	AWS from 2024-11-01 until 2026-04-07
+	Grafana Labs from 2026-04-07
 ymtdzzz: ymtdzzz!users.noreply.github.com
 	Independent
 ynambiar: ynambiar!users.noreply.github.com


### PR DESCRIPTION
Update Yoshi Yamaguchi's affiliation:

- Removing Yoshi's entry from Google
- Adding Yoshi's entry to Grafana Labs
- Change Yoshi's entry with the history of affiliations