### PR TITLE
Update affiliation for puckpuck: Honeycomb to Resolve AI

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -5925,10 +5925,11 @@ puce77: puce77!users.noreply.github.com
 	Swiss Federal Railways AG
 puckchen: puck.chen!hisilicon.com
 	Hisilicon Technologies Co. Ltd.
-puckpuck: pierre!honeycomb.io, pierre!pierretessier.com, puckpuck!users.noreply.github.com, puckpuck.com!gmail.com
+puckpuck: pierre!honeycomb.io, pierre!pierretessier.com, pierre!resolve.ai, puckpuck!users.noreply.github.com, puckpuck.com!gmail.com
 	Opentext Inc. until 2016-08-01
 	Wavefront from 2016-08-01 until 2020-04-06
-	Hound Technology Inc. dba Honeycomb from 2020-04-06
+	Hound Technology Inc. dba Honeycomb from 2020-04-06 until 2026-03-16
+	Resolve AI from 2026-03-16
 puddinman: puddinman!users.noreply.github.com
 	2K until 2016-05-01
 	Independent from 2016-05-01 until 2016-10-01


### PR DESCRIPTION
I changed employers on 2026-03-16, moving from Honeycomb (Hound Technology Inc. dba Honeycomb) to Resolve AI. This updates my affiliation in developers_affiliations8.txt and adds my new @ resolve.ai email.