### PR TITLE
docs: update Xunzhuo affiliation to AMD

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -13435,9 +13435,10 @@ Xunil32: tommy.dimitrio!gmail.com
 	Independent until 2016-03-01
 	ADS Assembly Data System from 2016-03-01 until 2018-07-01
 	KO2 SRL from 2018-07-01
-Xunzhuo: Xunzhuo!users.noreply.github.com, mixdeers!gmail.com
+Xunzhuo: Xunzhuo!users.noreply.github.com, mixdeers!gmail.com, xunzhuo.liu!amd.com
 	Independent until 2021-01-01
-	Tencent Holdings Limited from 2021-01-01
+	Tencent Holdings Limited from 2021-01-01 until 2026-08-01
+	AMD from 2026-08-01
 Xuxe: Xuxe!users.noreply.github.com, julian!julian-huebenthal.de
 	Independent
 Xyaren: Xyaren!users.noreply.github.com


### PR DESCRIPTION
## Summary
- Add xunzhuo.liu@amd.com to the historical email list.
- End the Tencent affiliation on 2026-08-01 and begin the AMD affiliation on the same date.
- Follow up on https://github.com/cncf/gitdm/pull/623.

## Test plan
- [x] git diff --check
