### PR TITLE
Add SetagGnaw affiliation (Independent)

### DIFF
--- a/developers_affiliations8.txt
+++ b/developers_affiliations8.txt
@@ -21916,6 +21916,8 @@ seswarrajan: seswarrajan!users.noreply.github.com
 	L&T Infotech from 2017-04-01 until 2019-02-01
 	Synamedia Vividtec Holdings Inc. from 2019-02-01 until 2021-08-01
 	Accuknox from 2021-08-01
+SetagGnaw: 9372086+SetagGnaw!users.noreply.github.com, gateswang00!gmail.com
+	Independent
 setassociative: rbailey!slack-corp.com, setassociative!users.noreply.github.com
 	Independent
 setcy: asetcy!gmail.com


### PR DESCRIPTION
Adds an affiliation entry for GitHub user SetagGnaw with current and historical commit emails (personal gmail plus the GitHub noreply address), affiliated as Independent, per the README section "Adding/Updating affiliation".