### PR TITLE
Add cardil gmail to affiliation entry

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -20543,8 +20543,9 @@ carbonin: carbonin!users.noreply.github.com, ncarboni!redhat.com
 	Red Hat Inc. from 2015-05-01
 carbonshow: wenzhitao515!qq.com
 	Tencent
-cardil: cardil!users.noreply.github.com, ksuszyns!redhat.com
-	Red Hat Inc.
+cardil: cardil!users.noreply.github.com, krzysztof.suszynski!gmail.com, ksuszyns!redhat.com
+	Independent until 2019-10-01
+	Red Hat Inc. from 2019-10-01
 cardoso: matheus!cardo.so
 	Independent until 2016-01-01
 	Apple Inc. from 2016-01-01 until 2017-12-01


### PR DESCRIPTION
Link `krzysztof.suszynski!gmail.com` to @cardil, so contributions made with that email are properly attributed to Red Hat.