### PR TITLE
Add affiliation for DigitalVeer

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -10327,6 +10327,9 @@ Digi59404: 774730+digi59404!users.noreply.github.com, Digi59404!users.noreply.gi
 	Tangerine from 2015-06-01 until 2017-07-01
 	Red Hat Inc. from 2017-07-01 until 2019-04-01
 	GitLab Inc. from 2019-04-01
+DigitalVeer: 8453348+digitalveer!users.noreply.github.com, digitalizedveer!gmail.com, digitalveer!google.com
+	Google LLC until 2026-08-01
+	Independent from 2026-08-01
 Dilergore: tibor.zold!tiborzold.com
 	Deutsche Telekom until 2017-01-01
 	XAPT from 2017-01-01 until 2018-08-01


### PR DESCRIPTION
Add my developer affiliation entry. I had no entry in the affiliations files.

The entry lists the three commit addresses in my Kubernetes contribution history:

- `digitalveer@google.com` --> the address used while I was at Google
- `digitalizedveer@gmail.com` --> my personal address
- `8453348+digitalveer@users.noreply.github.com` —-->my current GitHub noreply address