### PR TITLE
Update affiliations for Cozystack maintainers

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -15944,6 +15944,8 @@ IvanBiv: IvanBiv!users.noreply.github.com
 	INOGST LLC from 2019-03-01
 IvanGoncharov: ivan.goncharov.ua!gmail.com
 	APIs.guru
+IvanHunters: 49371933+IvanHunters!users.noreply.github.com, ivan.okhotnikov!aenix.io, xorokhotnikov!gmail.com
+	Ænix
 IvanJosipovic: IvanJosipovic!users.noreply.github.com
 	Softlanding until 2016-02-01
 	Independent from 2016-02-01 until 2016-12-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -12413,7 +12413,7 @@ kingasieminiak: kinga!sieminiak.com
 	intive from 2019-03-01 until 2019-09-01
 	Independent from 2019-09-01 until 2020-01-01
 	Zalando SE from 2020-01-01
-kingdonb: kingdon!teamhephy.com, kingdon!weave.works, kingdonb!users.noreply.github.com, yebyen!gmail.com
+kingdonb: kingdon!teamhephy.com, kingdon!urmanac.com, kingdon!weave.works, kingdonb!users.noreply.github.com, yebyen!gmail.com
 	Independent until 2021-01-18
 	Weaveworks Inc. from 2021-01-18 until 2023-12-29
 	Independent from 2023-12-29
@@ -18317,7 +18317,7 @@ lexdevelop: lexdevelop!users.noreply.github.com
 	Stanga1 from 2015-02-01 until 2016-12-01
 	Prime Holding from 2016-12-01 until 2024-07-01
 	Wiser from 2024-07-01
-lexfrei: 3811295!gmail.com, a.sviridkin!adguard.com, a.sviridkin!sdventures.com, aleksei.sviridkin!ringcentral.com, aleksey.sviridkin!aenix.io, asv!whenspeak.ru, asviridkin!7tech.ru, asviridkin!dtln.ru, asviridkin!ozon.ru, f!lex.la, lexfrei!users.noreply.github.com, sviridkin!restream.rt.ru, sviridkin!urusit.com
+lexfrei: 3811295!gmail.com, a.sviridkin!adguard.com, a.sviridkin!sdventures.com, aleksei.sviridkin!aenix.io, aleksei.sviridkin!ringcentral.com, aleksey.sviridkin!aenix.io, asv!whenspeak.ru, asviridkin!7tech.ru, asviridkin!dtln.ru, asviridkin!ozon.ru, f!lex.la, lexfrei!users.noreply.github.com, sviridkin!restream.rt.ru, sviridkin!urusit.com
 	ООО МАГ until 2014-09-01
 	Independent from 2014-09-01 until 2015-03-01
 	REG.RU from 2015-03-01 until 2015-09-01
@@ -19798,7 +19798,7 @@ llivingstone: llivingstone!users.noreply.github.com
 	BGN from 2015-08-01 until 2018-08-01
 	Independent from 2018-08-01 until 2019-09-01
 	Curve OS Limited from 2019-09-01
-lllamnyp: lllamnyp!users.noreply.github.com
+lllamnyp: lllamnyp!gmail.com, lllamnyp!users.noreply.github.com
 	Independent until 2018-10-01
 	X5 Group from 2018-10-01 until 2020-08-01
 	Tinkoff from 2020-08-01 until 2020-12-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -3498,7 +3498,7 @@ matthicksj: matthicksj!gmail.com, mhicks!redhat.com
 	Red Hat Inc.
 matthieu-pa: matthieu.parizy!gmail.com
 	Fujitsu Limited
-matthieu-robin: matthieu-robin!users.noreply.github.com
+matthieu-robin: info!matthieurobin.com, matthieu-robin!users.noreply.github.com
 	Vitol until 2015-03-01
 	Open from 2015-03-01 until 2018-08-01
 	Independent from 2018-08-01 until 2019-09-01
@@ -3530,6 +3530,8 @@ matthyx: matthias.bertschy!gmail.com, matthiasb!armosec.io, matthyx!users.norepl
 matti: matti!users.noreply.github.com
 	AppGyver Oy until 2018-05-01
 	SuperVisor Privilege Club from 2018-05-01
+mattia-eleuteri: mattia!hidora.io
+	Hidora
 mattiaforc: mattiaforc!gmail.com, mattiaforc!users.noreply.github.com
 	Independent until 2020-03-01
 	CINECA – Consorzio Interuniversitario from 2020-03-01 until 2021-01-01
@@ -14196,6 +14198,8 @@ myan9: mengting.yan1!ibm.com, myan9!users.noreply.github.com
 myaser: me.mahmoudgaballah!gmail.com
 	Kona until 2022-11-01
 	Zalando SE from 2022-11-01
+myasnikovdaniil: 60174387+myasnikovdaniil!users.noreply.github.com, myasnikovdaniil2001!gmail.com
+	Ænix
 myauie: louise!linux.com, myauie!gmail.com, myauie!users.noreply.github.com
 	Independent until 2017-07-01
 	LiveWyer Ltd from 2017-07-01

--- a/developers_affiliations9.txt
+++ b/developers_affiliations9.txt
@@ -18839,7 +18839,7 @@ tylrd: tylrd!users.noreply.github.com
 	Beth Bristow until 2015-05-01
 	Independent from 2015-05-01 until 2016-06-01
 	BetterCloud from 2016-06-01
-tym83: tym83!users.noreply.github.com
+tym83: 6355522!gmail.com, timur.tukaev!aenix.io, tym83!users.noreply.github.com
 	Independent until 2022-03-01
 	JetBrains s.r.o. from 2022-03-01 until 2023-01-01
 	ProductSense from 2023-01-01 until 2023-04-01


### PR DESCRIPTION
Affiliation updates for Cozystack maintainers, following the roster change in cncf/foundation#1489.

**Added** — three maintainers with no entry yet:

| Handle | Affiliation |
| --- | --- |
| `IvanHunters` (Ivan Okhotnikov) | Ænix |
| `mattia-eleuteri` (Mattia Eleuteri) | Hidora |
| `myasnikovdaniil` (Daniil Miasnikov) | Ænix |

**Emails only** — existing entries whose affiliation is already right but which carried only a `noreply` address: `kingdonb`, `lllamnyp`, `matthieu-robin`, `tym83`.

All addresses are taken from public commit authorship in the [cozystack/cozystack](https://github.com/cozystack/cozystack) repository, except `kingdon@urmanac.com`, which is listed publicly on that account's GitHub profile.

No affiliation periods are changed. The new entries carry no date ranges: I could verify the current affiliation but not a start date I would be willing to assert, and a wrong date seemed worse than none. Happy to add them if the maintainers supply them.

## AI disclosure

This change was prepared with the assistance of an AI agent (Claude Code). It collected the email addresses from public commit history, compared the existing entries against the project's `MAINTAINERS.md`, and produced the edits and this description. I reviewed the result and I am responsible for its accuracy.
