### PR TITLE
Add affiliation for pujitha24 (Independent)

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -23686,3 +23686,5 @@ MostlyAmiable: MostlyAmiable!users.noreply.github.com
 	Provi from 2020-09-01 until 2022-01-01
 	Meta Platforms Inc. from 2022-01-01 until 2023-05-01
 	Built Technologies from 2023-05-01
+pujitha24: 10557236+pujitha24!users.noreply.github.com
+	Independent


### PR DESCRIPTION
Adding my own affiliation entry to `developers_affiliations1.txt`.

My upstream contributions across CNCF projects are made independently, on personal time, so the affiliation is `Independent`.

Email used is the GitHub noreply address that all of my commits carry: `10557236+pujitha24@users.noreply.github.com`.

Thanks!