### PR TITLE
Add Sony-level developer affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -23686,3 +23686,5 @@ MostlyAmiable: MostlyAmiable!users.noreply.github.com
 	Provi from 2020-09-01 until 2022-01-01
 	Meta Platforms Inc. from 2022-01-01 until 2023-05-01
 	Built Technologies from 2023-05-01
+sony-level: 116947405+sony-level!users.noreply.github.com
+	Independent from 2026-08-08


### PR DESCRIPTION
This pull request makes a minor update to the `developers_affiliations1.txt` file, adding a new developer entry with their affiliation as "Independent" starting from 2026-08-08.