### PR TITLE
Add affiliation for yangligt2 (Google LLC)

### DIFF
--- a/developers_affiliations10.txt
+++ b/developers_affiliations10.txt
@@ -5046,6 +5046,8 @@ yangjw: xuerenxueren5669!user.noreply.github.com, yangjw!inspur.com, yangjw.kai7
 yangl900: yangl900!users.noreply.github.com
 	Microsoft Corporation until 2021-02-28
 	Databricks Inc. from 2021-02-28
+yangligt2: yangligt!google.com, yangligt2!users.noreply.github.com
+	Google LLC
 yanglong1010: yanglong1010!users.noreply.github.com
 	Independent until 2018-11-26
 	Alibaba Group from 2018-11-26

--- a/src/cncf-config/email-map
+++ b/src/cncf-config/email-map
@@ -274454,7 +274454,8 @@ yanglaoshi666!users.noreply.github.com NotFound
 yangle!fiberhome.com Fiberhome
 yangle!tenxcloud.com TenxCloud
 yangli_yl!qq.com NotFound
-yangligt2!users.noreply.github.com NotFound
+yangligt!google.com Google LLC
+yangligt2!users.noreply.github.com Google LLC
 yanglikun!users.noreply.github.com Jd.Com
 yangling94116!users.noreply.github.com NotFound
 yanglong1010!users.noreply.github.com Alibaba Group


### PR DESCRIPTION
Adding my developer affiliation for DevStats tracking, as part of the Kubernetes org membership requirements.

- GitHub username: yangligt2
- Emails: yangligt@google.com, yangligt2@users.noreply.github.com
- Affiliation: Google LLC (entire contribution period)

Updated developers_affiliations10.txt and the corresponding entries in src/cncf-config/email-map (replacing the existing NotFound entry for yangligt2!users.noreply.github.com).