### PR TITLE
Add affiliation for neoLsH (Alibaba Group)

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -16864,6 +16864,8 @@ neogopher: neogopher!users.noreply.github.com
 neolit123: lubomirivanov!vmware.com, neolit123!gmail.com, neolit123!users.noreply.github.com
 	VMware Inc. until 2023-05-01
 	Independent from 2023-05-01
+neoLsH: 43921685+neoLsH!users.noreply.github.com, huangleshu.hls!alibaba-inc.com
+	Alibaba Group
 neolunar7: neolunar7!gmail.com, neolunar7!users.noreply.github.com
 	Independent until 2019-08-01
 	Riiid from 2019-08-01 until 2021-08-01


### PR DESCRIPTION
Adding my own affiliation entry, covering the two emails I commit with:

- `43921685+neoLsH@users.noreply.github.com` (kubernetes and related repos)
- `huangleshu.hls@alibaba-inc.com` (other CNCF project contributions)

Signed-off per DCO.