### PR TITLE
Add affiliation for jessie1111101 (Google LLC)

### DIFF
--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -413,6 +413,9 @@ jessie-txt: jessie-txt!users.noreply.github.com
 	Boer from 2021-06-01 until 2021-09-01
 	Independent from 2021-09-01 until 2022-03-01
 	Inovasi from 2022-03-01
+jessie1111101: 58928222+jessie1111101!users.noreply.github.com, jssl!google.com
+	Independent until 2022-06-01
+	Google LLC from 2022-06-01
 jessiepuls: jessie.puls!dhigroupinc.com, jessiepuls!users.noreply.github.com
 	Independent until 2015-10-01
 	3Pillar Global from 2015-10-01 until 2017-07-01


### PR DESCRIPTION
Adding my own affiliation entry to `developers_affiliations6.txt`.

I'm not currently listed in any of the `developers_affiliations*.txt` shards, so this is a new entry rather than an update.

- GitHub login: `jessie1111101`
- Emails: GitHub noreply address, plus `jssl@google.com`, which is the author email on my commits to `kubernetes-sigs/devops-bench`
- Affiliation: Google LLC

Placed in ASCII key order between `jessie-txt` and `jessiepuls`. No other files touched, since the `company_developers*.txt` lists are generated derivatives.