### PR TITLE
Add marwan562 affiliation as Independent

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -3176,6 +3176,8 @@ marwan-at-work: marwan-at-work!users.noreply.github.com, marwan.sameer!gmail.com
 	New York Times from 2017-09-01 until 2019-09-01
 	InVision AG from 2019-09-01 until 2020-04-01
 	GitHub Inc. from 2020-04-01
+marwan562: marwan562!users.noreply.github.com, mixing.gamer546!gmail.com
+	Independent
 marwanad: marwanad!users.noreply.github.com, me!marwanad.com, mrwnad!gmail.com
 	Independent until 2015-05-01
 	Xe.com from 2015-05-01 until 2015-08-01


### PR DESCRIPTION
Add GitHub user marwan562 with emails marwan562!users.noreply.github.com, mixing.gamer546!gmail.com as Independent.

Required for Kubernetes org membership (CNCF gitdm affiliation up to date).