### PR TITLE
Update developer affiliation for @nestorsokil

### DIFF
--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -17275,7 +17275,8 @@ nestorsokil: nestor0603!gmail.com, nestorsokil!users.noreply.github.com
 	Soft Serve Inc. from 2015-11-01 until 2017-11-01
 	GlobalLogic Inc. from 2017-11-01 until 2018-11-01
 	Altigee from 2018-11-01 until 2019-09-01
-	Very Good Security from 2019-09-01
+	Very Good Security from 2019-09-01 until 2026-08-10
+	Dash0 Inc. from 2026-08-10
 net47: net47!users.noreply.github.com
 	schoeller until 2014-12-01
 	NTT Corporation from 2014-12-01 until 2018-10-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -17275,7 +17275,10 @@ nestorsokil: nestor0603!gmail.com, nestorsokil!users.noreply.github.com
 	Soft Serve Inc. from 2015-11-01 until 2017-11-01
 	GlobalLogic Inc. from 2017-11-01 until 2018-11-01
 	Altigee from 2018-11-01 until 2019-09-01
-	Very Good Security from 2019-09-01 until 2026-08-10
+	Very Good Security from 2019-09-01 until 2024-04-01
+	Independent from 2024-04-01 until 2024-08-01
+	Nexla from 2024-08-01 until 2026-04-01
+	Independent from 2026-04-01 until 2026-08-10
 	Dash0 Inc. from 2026-08-10
 net47: net47!users.noreply.github.com
 	schoeller until 2014-12-01


### PR DESCRIPTION
Brings the `nestorsokil` entry up to date: Very Good Security ended in March 2024, Nexla ran from August 2024 to March 2026, and Dash0 Inc. starts on 2026-08-10. The two gaps in between are Independent.

The `until` date of one period equals the `from` date of the next, matching the existing periods in this entry.
