### PR TITLE
Add big-kahuna-burger affiliation (Dash0 Inc.)

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -14778,6 +14778,8 @@ bidipeppercrap: bidipeppercrap!users.noreply.github.com
 	bidipeppercrap
 big-henry: henry!bigtera.com, henry_chang!bigtera.com
 	Bigtera
+big-kahuna-burger: 11753867+big-kahuna-burger!users.noreply.github.com, arandjel.sarenac!dash0.com
+	Dash0 Inc. from 2026-06-22
 bigLucas: bigLucas!users.noreply.github.com
 	Steintec Automação until 2016-11-01
 	Empresas Guimarães from 2016-11-01 until 2019-07-01


### PR DESCRIPTION
Adding my own affiliation entry to `developers_affiliations3.txt`.

I'm not currently listed in any of the `developers_affiliations*.txt` shards,
so this is a new entry rather than an update.

- GitHub login: `big-kahuna-burger` (Aranđel Šarenac)
- Emails: `11753867+big-kahuna-burger@users.noreply.github.com`,
  `arandjel.sarenac@dash0.com`
- Affiliation: Dash0 Inc. from 2026-06-22 (no prior affiliations to record)

Placed in ASCII order between `big-henry` and `bigLucas`. Company string
matches the existing `Dash0 Inc.` entries.