### PR TITLE
Update FredrikAugust affiliation to Dash0 Inc.

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -12995,7 +12995,8 @@ FredrikAugust: FredrikAugust!users.noreply.github.com, mail.fredrikaugust!gmail.
 	Kodeworks from 2017-09-01 until 2021-05-01
 	Bekk Seasonal from 2021-05-01 until 2021-07-01
 	Alv AS from 2021-07-01 until 2023-03-01
-	Kvist from 2023-03-01
+	Kvist from 2023-03-01 until 2026-01-01
+	Dash0 Inc. from 2026-01-01
 FredrikMeyer: hrmeyer!gmail.com
 	Independent until 2017-08-01
 	Bekk Consulting AS from 2017-08-01 until 2020-02-01


### PR DESCRIPTION
Attribute FredrikAugust's contributions to Dash0 Inc. starting January 1, 2026. The exclusive `until 2026-01-01` cutoff keeps December 31, 2025 attributed to Kvist.

Date-boundary checks, `git diff --check`, and the repository's forbidden-data check passed. Full data regeneration was not run.
