### PR TITLE
Add affiliation entry for asubiotto

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -9142,6 +9142,12 @@ asubedy: asubedy!users.noreply.github.com
 	Independent until 2020-12-01
 	AccioJob from 2020-12-01 until 2021-05-01
 	D_CODER DTU from 2021-05-01
+asubiotto: alfonso!cockroachlabs.com, alfonso.subiotto!dash0.com, alfonso.subiotto!polarsignals.com, asubiotto!users.noreply.github.com
+	Independent until 2016-09-01
+	Cockroach Labs from 2016-09-01 until 2021-04-01
+	Independent from 2021-04-01 until 2022-08-01
+	Polar Signals from 2022-08-01 until 2026-08-01
+	Dash0 Inc. from 2026-08-01
 asubmani: asubmani!gmail.com, asubmani!users.noreply.github.com
 	Microsoft Corporation until 2019-03-01
 	CloudIQ from 2019-03-01


### PR DESCRIPTION
Adds my affiliation history to `developers_affiliations3.txt`. My current employer is Dash0 Inc.

Previously I was only present in `src/cncf-config/email-map`, mapped to Cockroach Labs, with no entry in the affiliations list.

```
asubiotto: alfonso!cockroachlabs.com, alfonso.subiotto!dash0.com, alfonso.subiotto!polarsignals.com, asubiotto!users.noreply.github.com
	Independent until 2016-09-01
	Cockroach Labs from 2016-09-01 until 2021-04-01
	Independent from 2021-04-01 until 2022-08-01
	Polar Signals from 2022-08-01 until 2026-08-01
	Dash0 Inc. from 2026-08-01
```

All company names match entries already present in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)